### PR TITLE
feat(hydrate): embedded resolution, parallel media, live progress

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -63,13 +63,14 @@ core plugin resolver applies that page window to the normalized envelope and
 adds `offset`, `limit`, `returned`, `totalCount`, `hasMore`, and `nextOffset`
 pagination fields where applicable.
 
-Omit `traverse` or set it to `True` when generic embedded target traversal may
-follow the listed target. Set `traverse` to `False` when the item should be
-visible to listing and inspection, but should not be followed by `target-depth`.
+Omit `traverse` or set it to `True` when embedded resolution may follow the listed
+target from a collected item. Set `traverse` to `False` when the item should be
+visible to listing and inspection, but should not be resolved as attached
+context.
 
 `materialize` lets a plugin expose a listed child target as one or more ordinary
-files so the normal resolver stack can claim them. This is for embedded targets
-such as a Discord attachment that should be re-read as a zip, image, or audio
+files so the normal resolver stack can claim them. This is for embedded
+targets such as an attachment that should be re-read as a zip, image, or audio
 file instead of being rendered by the parent provider. It should return items
 shaped like:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,13 +5,15 @@
 
 - `-p, --prompt` prepend and optionally append up to two strings
 - `-w, --wrap` wrap output as `md` or `xml`; `-w` alone is a shorthand for `--wrap xml`
-- `--verbose` enable provider progress logs on stderr
+- `--verbose` enable provider diagnostics, Rich live progress on interactive stderr, and an end-of-run progress summary
 - `--quiet` disable provider progress logs on stderr (default)
 - `-c, --copy` copy to clipboard instead of printing; displays the token count
 - `-s, --staged-copy` with `--prompt` and a copy mode, copy preprompt, content, and postprompt as distinct stages
 - `--count` dry run of `--copy`; prints a string containing the token count
 - `--write-file PATH` write final output to a file
 - `--token-target STR` choose the encoding/model for token counting (e.g. `cl100k_base`, `gpt-4o-mini`, `claude-3-5-sonnet-20241022`)
+- `--spec-jobs N` set parallel file-spec resolution jobs; defaults to `CONTEXTUALIZE_PAYLOAD_SPEC_JOBS` or `8`
+- `--media-jobs N` set parallel embedded/media processing jobs; defaults to `CONTEXTUALIZE_PAYLOAD_MEDIA_JOBS` or `4`
 - `-a, --after` / `-b, --before` control placement in pipelines (default: after)
 
 `--count` cannot be combined with `--copy` or `--copy-segments`.

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -115,9 +115,9 @@ in
 
       activation = {
         mode = mkOption {
-          type = types.enum [ "service" "inline" ];
+          type = types.enum [ "service" "inline" "manual" ];
           default = if pkgs.stdenv.isLinux then "service" else "inline";
-          description = "Run context hydration through a non-blocking user service or inline during activation.";
+          description = "Run context hydration through a non-blocking user service, inline during activation, or manually through the generated service.";
         };
 
         after = mkOption {
@@ -147,7 +147,7 @@ in
     systemd.user.services.contextualize-contexts-hydrate = lib.mkIf (
       pkgs.stdenv.isLinux
       && cfg.contexts.enable
-      && cfg.contexts.activation.mode == "service"
+      && (cfg.contexts.activation.mode == "service" || cfg.contexts.activation.mode == "manual")
     ) {
       Unit = {
         Description = "Hydrate contextualize context registry";
@@ -170,7 +170,10 @@ in
       ''
     );
 
-    home.activation.contextualizeContextsHydrate = lib.mkIf cfg.contexts.enable (
+    home.activation.contextualizeContextsHydrate = lib.mkIf (
+      cfg.contexts.enable
+      && cfg.contexts.activation.mode != "manual"
+    ) (
       lib.hm.dag.entryAfter (
         cfg.contexts.activation.after
         ++ lib.optional (cfg.contexts.activation.mode == "service") "reloadSystemd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "pyperclip>=1.8.2",
   "tiktoken>=0.6.0",
   "requests>=2.25.0",
+  "rich>=14.1.0",
   "markitdown[all]>=0.1.4",
 ]
 

--- a/src/contextualize/cli.py
+++ b/src/contextualize/cli.py
@@ -35,6 +35,8 @@ GLOBAL_OPTION_LABELS = (
     ("md_model", "--md-model"),
     ("md_image_provider", "--md-image-provider"),
     ("codex_app_server_command", "--codex-app-server-command"),
+    ("spec_jobs", "--spec-jobs"),
+    ("media_jobs", "--media-jobs"),
     ("output_position", "--position"),
     ("append_flag", "--after"),
     ("prepend_flag", "--before"),
@@ -55,9 +57,24 @@ GLOBAL_OPTION_DEFAULTS = {
     "md_model": None,
     "md_image_provider": None,
     "codex_app_server_command": None,
+    "spec_jobs": None,
+    "media_jobs": None,
     "output_position": None,
     "append_flag": False,
     "prepend_flag": False,
+}
+HYDRATE_IGNORED_GLOBAL_OPTION_NAMES = {
+    "prompt",
+    "wrap_short",
+    "wrap_mode",
+    "copy",
+    "staged_copy",
+    "count_only",
+    "copy_segments",
+    "write_file",
+    "output_position",
+    "append_flag",
+    "prepend_flag",
 }
 
 _STDIN_URL_RE = re.compile(r"https?://[^\s<>'\"`]+")
@@ -162,7 +179,11 @@ def _write_bold_section(
     formatter.dedent()
 
 
-def _collect_used_global_option_labels(ctx: click.Context) -> list[str]:
+def _collect_used_global_option_labels(
+    ctx: click.Context,
+    *,
+    only_names: set[str] | None = None,
+) -> list[str]:
     parent = ctx.parent
     if parent is None:
         return []
@@ -172,12 +193,16 @@ def _collect_used_global_option_labels(ctx: click.Context) -> list[str]:
     used: list[str] = []
     if callable(get_source):
         for name, label in GLOBAL_OPTION_LABELS:
+            if only_names is not None and name not in only_names:
+                continue
             if name not in parent.params:
                 continue
             if get_source(name) == click.core.ParameterSource.COMMANDLINE:
                 used.append(label)
         return used
     for name, label in GLOBAL_OPTION_LABELS:
+        if only_names is not None and name not in only_names:
+            continue
         if name not in parent.params:
             continue
         if parent.params.get(name) != GLOBAL_OPTION_DEFAULTS.get(name):
@@ -436,6 +461,8 @@ def preprocess_args():
         "--md-model",
         "--md-image-provider",
         "--codex-app-server-command",
+        "--spec-jobs",
+        "--media-jobs",
         "--position",
         "--verbose",
         "--quiet",
@@ -450,6 +477,8 @@ def preprocess_args():
         "--md-model",
         "--md-image-provider",
         "--codex-app-server-command",
+        "--spec-jobs",
+        "--media-jobs",
         "--position",
     }
     short_forwardable = {"-p", "-w", "-c", "-s", "-a", "-b"}
@@ -639,6 +668,24 @@ preprocess_args()
     ),
 )
 @click.option(
+    "--spec-jobs",
+    type=click.IntRange(1, 64),
+    default=None,
+    help=(
+        "Parallel file-spec resolution jobs. Overrides "
+        "CONTEXTUALIZE_PAYLOAD_SPEC_JOBS (default: 8)."
+    ),
+)
+@click.option(
+    "--media-jobs",
+    type=click.IntRange(1, 64),
+    default=None,
+    help=(
+        "Parallel embedded/media processing jobs. Overrides "
+        "CONTEXTUALIZE_PAYLOAD_MEDIA_JOBS (default: 4)."
+    ),
+)
+@click.option(
     "--verbose",
     is_flag=True,
     help="Enable provider progress logs on stderr.",
@@ -676,6 +723,8 @@ def cli(
     md_model,
     md_image_provider,
     codex_app_server_command,
+    spec_jobs,
+    media_jobs,
     verbose,
     quiet,
     output_position,
@@ -716,6 +765,8 @@ def cli(
             raise click.BadParameter("--codex-app-server-command cannot be empty")
         os.environ["CODEX_APP_SERVER_COMMAND"] = command
     ctx.obj["codex_app_server_command"] = codex_app_server_command
+    ctx.obj["spec_jobs"] = spec_jobs
+    ctx.obj["media_jobs"] = media_jobs
     if append_flag and prepend_flag:
         raise click.BadParameter("use -a or -b, not both")
     if copy and copy_segments:
@@ -731,11 +782,21 @@ def cli(
     if staged_copy and write_file:
         raise click.BadParameter("--staged-copy cannot be used with --write-file")
 
+    from .progress import reset_progress, set_live_progress
     from .run_metadata import reset_run_metadata
-    from .runtime import set_verbose_logging
+    from .runtime import (
+        set_payload_media_jobs,
+        set_payload_spec_jobs,
+        set_verbose_logging,
+    )
 
+    reset_progress()
     reset_run_metadata()
     set_verbose_logging(verbose_logging)
+    set_payload_spec_jobs(spec_jobs)
+    set_payload_media_jobs(media_jobs)
+    set_live_progress(verbose_logging)
+    ctx.call_on_close(lambda: _finish_run(verbose_logging=verbose_logging))
 
     if append_flag:
         output_pos = "append"
@@ -776,6 +837,19 @@ def cli(
         else:
             click.echo(ctx.get_help())
             ctx.exit()
+
+
+def _finish_run(*, verbose_logging: bool) -> None:
+    from .progress import flush_progress_summary, set_live_progress
+
+    set_live_progress(False)
+    flush_progress_summary(enabled=verbose_logging)
+    try:
+        from .render.codex import close_shared_codex_app_server_sessions
+
+        close_shared_codex_app_server_sessions()
+    except Exception:
+        pass
 
 
 @cli.result_callback()
@@ -1425,9 +1499,7 @@ def _context_hydrate_overrides(
     transcribe_refresh,
     refresh_all,
     cache_ttl,
-    target_depth,
-    target_scope,
-    include_parent,
+    embedded_resolution,
     extra_params,
 ):
     from .plugins import collect_plugin_cli_overrides
@@ -1482,9 +1554,7 @@ def _context_hydrate_overrides(
         cache_ttl=parsed_cache_ttl,
         refresh_cache=refresh_cache,
         plugin_overrides=plugin_overrides,
-        target_depth=target_depth,
-        target_scope=target_scope.lower() if target_scope else None,
-        include_parent=include_parent,
+        embedded_resolution=embedded_resolution,
     )
 
 
@@ -1662,21 +1732,9 @@ def contexts_status_cmd(status_path) -> None:
     help="Cache TTL (e.g., 7d, 24h, 1w). Overrides manifest config.",
 )
 @click.option(
-    "--target-depth",
-    type=int,
+    "--embedded-resolution/--no-embedded-resolution",
     default=None,
-    help="Follow embedded plugin targets this many levels deep.",
-)
-@click.option(
-    "--target-scope",
-    type=click.Choice(["first", "all"], case_sensitive=False),
-    default=None,
-    help="Resolve embedded targets from only the first input or all inputs.",
-)
-@click.option(
-    "--include-parent/--children-only",
-    default=None,
-    help="Include original targets when embedded targets are followed.",
+    help="Resolve embedded plugin targets attached to collected items.",
 )
 @_video_frame_options
 @click.pass_context
@@ -1702,13 +1760,14 @@ def contexts_hydrate_cmd(
     transcribe_refresh,
     refresh_all,
     cache_ttl,
-    target_depth,
-    target_scope,
-    include_parent,
+    embedded_resolution,
     **extra_params,
 ):
     """Hydrate one or more registered contexts."""
-    used_options = _collect_used_global_option_labels(ctx)
+    used_options = _collect_used_global_option_labels(
+        ctx,
+        only_names=HYDRATE_IGNORED_GLOBAL_OPTION_NAMES,
+    )
     if used_options:
         click.echo(f"ignoring global options [{', '.join(used_options)}]", err=True)
 
@@ -1732,9 +1791,7 @@ def contexts_hydrate_cmd(
         transcribe_refresh=transcribe_refresh,
         refresh_all=refresh_all,
         cache_ttl=cache_ttl,
-        target_depth=target_depth,
-        target_scope=target_scope,
-        include_parent=include_parent,
+        embedded_resolution=embedded_resolution,
         extra_params=extra_params,
     )
     try:
@@ -1848,21 +1905,9 @@ def contexts_hydrate_cmd(
     help="Cache TTL (e.g., 7d, 24h, 1w). Overrides manifest config.",
 )
 @click.option(
-    "--target-depth",
-    type=int,
+    "--embedded-resolution/--no-embedded-resolution",
     default=None,
-    help="Follow embedded plugin targets this many levels deep.",
-)
-@click.option(
-    "--target-scope",
-    type=click.Choice(["first", "all"], case_sensitive=False),
-    default=None,
-    help="Resolve embedded targets from only the first input ('first') or all inputs ('all').",
-)
-@click.option(
-    "--include-parent/--children-only",
-    default=None,
-    help="Include original targets when embedded targets are followed.",
+    help="Resolve embedded plugin targets attached to collected items.",
 )
 @click.option(
     "--trace",
@@ -1891,9 +1936,7 @@ def hydrate_cmd(
     transcribe_refresh,
     refresh_all,
     cache_ttl,
-    target_depth,
-    target_scope,
-    include_parent,
+    embedded_resolution,
     trace,
     **extra_params,
 ):
@@ -1904,7 +1947,10 @@ def hydrate_cmd(
     Are.na channels, Discord URLs, SoundCloud URLs/URNs, YouTube URLs, or a single
     YAML manifest file.
     """
-    used_options = _collect_used_global_option_labels(ctx)
+    used_options = _collect_used_global_option_labels(
+        ctx,
+        only_names=HYDRATE_IGNORED_GLOBAL_OPTION_NAMES,
+    )
     if used_options:
         click.echo(f"ignoring global options [{', '.join(used_options)}]", err=True)
 
@@ -1969,9 +2015,7 @@ def hydrate_cmd(
         cache_ttl=parsed_cache_ttl,
         refresh_cache=refresh_cache,
         plugin_overrides=plugin_overrides,
-        target_depth=target_depth,
-        target_scope=target_scope.lower() if target_scope else None,
-        include_parent=include_parent,
+        embedded_resolution=embedded_resolution,
     )
 
     manifest_path = None
@@ -2012,9 +2056,7 @@ def hydrate_cmd(
                 cache_ttl=parsed_cache_ttl,
                 refresh_cache=refresh_cache,
                 plugin_overrides=plugin_overrides,
-                target_depth=target_depth or 0,
-                target_scope=(target_scope or "all").lower(),
-                include_parent=True if include_parent is None else include_parent,
+                embedded_resolution=bool(embedded_resolution),
             )
         except (ValueError, FileNotFoundError) as exc:
             raise click.ClickException(str(exc)) from exc
@@ -2195,21 +2237,9 @@ def hydrate_cmd(
     help="Paths to skip when resolving Markdown links. Can be specified multiple times.",
 )
 @click.option(
-    "--target-depth",
-    type=int,
-    default=0,
-    help="Follow embedded plugin targets this many levels deep.",
-)
-@click.option(
-    "--target-scope",
-    type=click.Choice(["first", "all"], case_sensitive=False),
-    default="all",
-    help="Resolve embedded targets from only the first input ('first') or all inputs ('all').",
-)
-@click.option(
-    "--include-parent/--children-only",
-    default=True,
-    help="Include the original target when embedded targets are followed.",
+    "--embedded-resolution/--no-embedded-resolution",
+    default=False,
+    help="Resolve embedded plugin targets attached to collected items.",
 )
 @click.option(
     "--trace",
@@ -2307,9 +2337,7 @@ def cat_cmd(
     link_depth,
     link_scope,
     link_skip,
-    target_depth,
-    target_scope,
-    include_parent,
+    embedded_resolution,
     trace,
     list_mode,
     rev,
@@ -2429,9 +2457,7 @@ def cat_cmd(
                 cache_ttl=parsed_cache_ttl,
                 refresh_cache=refresh_cache,
                 plugin_overrides=plugin_overrides,
-                target_depth=target_depth,
-                target_scope=target_scope.lower(),
-                include_parent=include_parent,
+                embedded_resolution=embedded_resolution,
                 text_only=text_only,
                 binary_policy=binary_policy,
             )

--- a/src/contextualize/concurrency.py
+++ b/src/contextualize/concurrency.py
@@ -1,32 +1,84 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from contextvars import copy_context
+from contextvars import ContextVar, copy_context
+import threading
 from typing import Any, Callable
+
+_MEDIA_SEMAPHORE_LOCK = threading.Lock()
+_MEDIA_SEMAPHORE: tuple[int, threading.BoundedSemaphore] | None = None
+_MEDIA_SEMAPHORE_DEPTH: ContextVar[int] = ContextVar(
+    "contextualize_media_semaphore_depth", default=0
+)
 
 
 def run_indexed_tasks_fail_fast(
     tasks: list[tuple[int, Callable[[], Any]]],
     *,
     max_workers: int,
+    semaphore: threading.BoundedSemaphore | None = None,
+    on_complete: Callable[[int, Any], None] | None = None,
 ) -> list[tuple[int, Any]]:
     if not tasks:
         return []
     if max_workers <= 1 or len(tasks) == 1:
-        return [(index, task()) for index, task in tasks]
+        completed = []
+        for index, task in tasks:
+            result = _run_with_semaphore(task, semaphore)
+            if on_complete is not None:
+                on_complete(index, result)
+            completed.append((index, result))
+        return completed
 
     results: dict[int, Any] = {}
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_to_index = {
-            executor.submit(copy_context().run, task): index for index, task in tasks
+            executor.submit(
+                copy_context().run,
+                _run_with_semaphore,
+                task,
+                semaphore,
+            ): index
+            for index, task in tasks
         }
         try:
             for future in as_completed(future_to_index):
                 index = future_to_index[future]
-                results[index] = future.result()
+                result = future.result()
+                results[index] = result
+                if on_complete is not None:
+                    on_complete(index, result)
         except Exception:
             for future in future_to_index:
                 future.cancel()
             raise
 
     return [(index, results[index]) for index in sorted(results)]
+
+
+def media_task_semaphore() -> threading.BoundedSemaphore:
+    from .runtime import get_payload_media_jobs
+
+    jobs = get_payload_media_jobs()
+    global _MEDIA_SEMAPHORE
+    with _MEDIA_SEMAPHORE_LOCK:
+        if _MEDIA_SEMAPHORE is None or _MEDIA_SEMAPHORE[0] != jobs:
+            _MEDIA_SEMAPHORE = (jobs, threading.BoundedSemaphore(jobs))
+        return _MEDIA_SEMAPHORE[1]
+
+
+def _run_with_semaphore(
+    task: Callable[[], Any],
+    semaphore: threading.BoundedSemaphore | None,
+) -> Any:
+    if semaphore is None:
+        return task()
+    depth = _MEDIA_SEMAPHORE_DEPTH.get()
+    if depth > 0:
+        return task()
+    with semaphore:
+        token = _MEDIA_SEMAPHORE_DEPTH.set(depth + 1)
+        try:
+            return task()
+        finally:
+            _MEDIA_SEMAPHORE_DEPTH.reset(token)

--- a/src/contextualize/manifest/build.py
+++ b/src/contextualize/manifest/build.py
@@ -80,6 +80,18 @@ def _combine_comment(comment: str | None, output: str) -> str:
     return output
 
 
+def _reject_removed_embedded_traversal_keys(mapping: dict[str, Any], label: str) -> None:
+    removed = [
+        key for key in ("target-depth", "target-scope", "include-parent") if key in mapping
+    ]
+    if not removed:
+        return
+    keys = ", ".join(removed)
+    raise ValueError(
+        f"{label} uses removed embedded traversal key(s): {keys}. Use embedded-resolution instead."
+    )
+
+
 def _resolve_spec_to_paths(
     raw_spec: str,
     base_dir: str,
@@ -186,9 +198,7 @@ def _resolve_spec_to_seed_refs(
     cache_ttl: timedelta | None = None,
     refresh_cache: bool = False,
     plugin_overrides: dict[str, Any] | None = None,
-    target_depth: int = 0,
-    target_scope: str = "all",
-    include_parent: bool = True,
+    embedded_resolution: bool = False,
 ) -> tuple[List[Any], List[Any], List[tuple[str, str, int]]]:
     spec = os.path.expanduser(raw_spec)
     opts = parse_target_spec(spec)
@@ -253,9 +263,7 @@ def _resolve_spec_to_seed_refs(
                     cache_ttl=cache_ttl,
                     refresh_cache=refresh_cache,
                     plugin_overrides=plugin_overrides,
-                    target_depth=target_depth,
-                    target_scope=target_scope,
-                    include_parent=include_parent,
+                    embedded_resolution=embedded_resolution,
                 )["refs"]
                 seed_refs.extend(refs)
                 trace_inputs.extend([ref for ref in refs if hasattr(ref, "path")])
@@ -272,9 +280,7 @@ def _resolve_spec_to_seed_refs(
             cache_ttl=cache_ttl,
             refresh_cache=refresh_cache,
             plugin_overrides=plugin_overrides,
-            target_depth=target_depth,
-            target_scope=target_scope,
-            include_parent=include_parent,
+            embedded_resolution=embedded_resolution,
         )["refs"]
         for ref in refs:
             _append_wrapped_ref(ref, url)
@@ -292,9 +298,7 @@ def _resolve_spec_to_seed_refs(
             cache_ttl=cache_ttl,
             refresh_cache=refresh_cache,
             plugin_overrides=plugin_overrides,
-            target_depth=target_depth,
-            target_scope=target_scope,
-            include_parent=include_parent,
+            embedded_resolution=embedded_resolution,
         )["refs"]
         for ref in refs:
             _append_wrapped_ref(ref, target)
@@ -338,9 +342,7 @@ def _resolve_spec_to_seed_refs(
                 label_suffix=label_suffix,
                 inject=inject,
                 depth=depth,
-                target_depth=target_depth,
-                target_scope=target_scope,
-                include_parent=include_parent,
+                embedded_resolution=embedded_resolution,
             )["refs"]
             seed_refs.extend(refs)
 
@@ -400,9 +402,7 @@ def _resolve_spec(
     per_file_link_depth: int | None,
     per_file_link_scope: str,
     resolved_link_skip: list[str],
-    target_depth: int,
-    target_scope: str,
-    include_parent: bool,
+    embedded_resolution: bool,
     use_cache: bool,
     cache_ttl: timedelta | None,
     refresh_cache: bool,
@@ -443,9 +443,7 @@ def _resolve_spec(
             cache_ttl=cache_ttl,
             refresh_cache=refresh_cache,
             plugin_overrides=plugin_overrides,
-            target_depth=target_depth,
-            target_scope=target_scope,
-            include_parent=include_parent,
+            embedded_resolution=embedded_resolution,
         )
     )
 
@@ -513,9 +511,7 @@ def build_payload_impl(
     link_depth_default: int = 0,
     link_scope_default: str = "all",
     link_skip_default: List[str] = None,
-    target_depth_default: int = 0,
-    target_scope_default: str = "all",
-    include_parent_default: bool = True,
+    embedded_resolution_default: bool = False,
     exclude_keys: list[str] | None = None,
     map_mode: bool = False,
     map_keys: list[str] | None = None,
@@ -576,17 +572,10 @@ def build_payload_impl(
 
         comp_link_depth = int(comp.get("link-depth", link_depth_default) or 0)
         comp_link_scope = (comp.get("link-scope", link_scope_default) or "all").lower()
-        comp_target_depth = int(comp.get("target-depth", target_depth_default) or 0)
-        comp_target_scope = (
-            comp.get("target-scope", target_scope_default) or "all"
-        ).lower()
-        if comp_target_scope not in {"first", "all"}:
-            raise ValueError(
-                f"Component '{name}' target-scope must be 'first' or 'all'"
-            )
-        comp_include_parent = comp.get("include-parent", include_parent_default)
-        if not isinstance(comp_include_parent, bool):
-            raise ValueError(f"Component '{name}' include-parent must be a boolean")
+        _reject_removed_embedded_traversal_keys(comp, f"Component '{name}'")
+        comp_embedded_resolution = comp.get("embedded-resolution", embedded_resolution_default)
+        if not isinstance(comp_embedded_resolution, bool):
+            raise ValueError(f"Component '{name}' embedded-resolution must be a boolean")
 
         comp_link_skip = comp.get("link-skip", link_skip_default)
         if comp_link_skip is None:
@@ -617,29 +606,15 @@ def build_payload_impl(
                 else comp_link_scope
             )
             per_file_link_skip = file_opts.get("link-skip") if file_opts else None
-            per_file_target_depth_raw = file_opts.get("target-depth")
-            per_file_target_depth = (
-                int(per_file_target_depth_raw)
-                if per_file_target_depth_raw is not None
-                else comp_target_depth
+            _reject_removed_embedded_traversal_keys(
+                file_opts, f"Component '{name}' file[{spec_index}]"
             )
-            per_file_target_scope = (
-                (file_opts.get("target-scope") or comp_target_scope).lower()
-                if file_opts
-                else comp_target_scope
+            per_file_embedded_resolution = file_opts.get(
+                "embedded-resolution", comp_embedded_resolution
             )
-            if per_file_target_scope not in {"first", "all"}:
+            if not isinstance(per_file_embedded_resolution, bool):
                 raise ValueError(
-                    f"Component '{name}' file[{spec_index}] target-scope must be 'first' or 'all'"
-                )
-            per_file_include_parent = (
-                file_opts.get("include-parent")
-                if "include-parent" in file_opts
-                else comp_include_parent
-            )
-            if not isinstance(per_file_include_parent, bool):
-                raise ValueError(
-                    f"Component '{name}' file[{spec_index}] include-parent must be a boolean"
+                    f"Component '{name}' file[{spec_index}] embedded-resolution must be a boolean"
                 )
             resolved_link_skip = list(resolved_link_skip_default)
             if per_file_link_skip:
@@ -654,7 +629,7 @@ def build_payload_impl(
             spec_tasks.append(
                 (
                     spec_index,
-                    lambda rs=raw_spec, fo=file_opts, ic=item_comment, pld=per_file_link_depth, pls=per_file_link_scope, rls=resolved_link_skip, td=per_file_target_depth, ts=per_file_target_scope, ip=per_file_include_parent: (
+                    lambda rs=raw_spec, fo=file_opts, ic=item_comment, pld=per_file_link_depth, pls=per_file_link_scope, rls=resolved_link_skip, er=per_file_embedded_resolution: (
                         _resolve_spec(
                             raw_spec=rs,
                             file_opts=fo,
@@ -669,9 +644,7 @@ def build_payload_impl(
                             per_file_link_depth=pld,
                             per_file_link_scope=pls,
                             resolved_link_skip=rls,
-                            target_depth=td,
-                            target_scope=ts,
-                            include_parent=ip,
+                            embedded_resolution=er,
                             use_cache=use_cache,
                             cache_ttl=cache_ttl,
                             refresh_cache=refresh_cache,

--- a/src/contextualize/manifest/contexts.py
+++ b/src/contextualize/manifest/contexts.py
@@ -11,6 +11,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ..progress import (
+    log_progress,
+    reset_progress_context,
+    set_progress_context,
+    write_progress_log,
+)
 from .hydrate import (
     HydrateOverrides,
     HydrateResult,
@@ -89,7 +95,9 @@ def hydrate_contexts(
     effective_overrides = overrides or HydrateOverrides()
     statuses: list[ContextHydrationStatus] = []
 
+    log_progress("hydrate", "context", "total", count=len(selected_names))
     for name in selected_names:
+        log_progress("hydrate", "context", "start", target=name)
         context = contexts.get(name)
         if context is None:
             statuses.append(
@@ -103,9 +111,28 @@ def hydrate_contexts(
                     replace="guarded",
                 )
             )
+            log_progress(
+                "hydrate",
+                "context",
+                "failed",
+                target=name,
+                detail="not registered",
+            )
             continue
         with redirect_stderr(_ContextStderrPrefixer(context.name, sys.stderr)):
-            statuses.append(_hydrate_one(context, effective_overrides))
+            token = set_progress_context(context.name)
+            try:
+                status = _hydrate_one(context, effective_overrides)
+            finally:
+                reset_progress_context(token)
+        statuses.append(status)
+        log_progress(
+            "hydrate",
+            "context",
+            "failed" if status.result == "failed" else "done",
+            target=name,
+            detail=status.result,
+        )
 
     write_context_status(statuses, status_path=status_path)
     return statuses
@@ -378,7 +405,11 @@ class _ContextStderrPrefixer:
         self.target.flush()
 
     def _write_line(self, line: str, *, newline: bool) -> None:
+        handled = False
         if line:
-            self.target.write(f"context {self.name}: {line}")
-        if newline:
+            prefixed = f"context {self.name}: {line}"
+            handled = write_progress_log(prefixed)
+            if not handled:
+                self.target.write(prefixed)
+        if newline and not handled:
             self.target.write("\n")

--- a/src/contextualize/manifest/hydrate.py
+++ b/src/contextualize/manifest/hydrate.py
@@ -17,11 +17,12 @@ from ..git.cache import ensure_repo, expand_git_paths
 from ..git.target import parse_git_target
 from ..git.rev import get_repo_root, read_gitignore_patterns
 from ..plugins import (
-    classify_plugin_target,
     loaded_plugin_names,
     normalize_manifest_plugin_config,
+    plugin_target_provider,
 )
 from ..plugins.reference import PluginReference
+from ..progress import log_progress
 from ..references import URLReference, create_file_references
 from ..runtime import get_payload_spec_jobs
 from ..references.helpers import (
@@ -77,9 +78,7 @@ class HydrateOverrides:
     cache_ttl: timedelta | None = None
     refresh_cache: bool = False
     plugin_overrides: dict[str, Any] | None = None
-    target_depth: int | None = None
-    target_scope: str | None = None
-    include_parent: bool | None = None
+    embedded_resolution: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -111,6 +110,7 @@ class ResolvedItem:
     plugin_dedupe_mode: str | None = None
     plugin_dedupe_key: str | None = None
     plugin_dedupe_rank: int | None = None
+    plugin_dedupe_link: bool = True
     arena_kind: str | None = None
     arena_channel_id: str | None = None
     arena_depth: int | None = None
@@ -151,6 +151,8 @@ class _PluginPendingWrite:
 
 
 def apply_hydration_plan(plan: HydratePlan) -> HydrateResult:
+    file_count = _hydration_file_count(plan)
+    log_progress("hydrate", "file", "total", count=file_count)
     _write_files(plan.files_to_write)
     _copy_files(plan.files_to_copy)
     _create_symlinks(plan.files_to_symlink)
@@ -159,10 +161,7 @@ def apply_hydration_plan(plan: HydratePlan) -> HydrateResult:
     if plan.access == "read-only":
         _apply_read_only(plan.context_dir)
 
-    written_paths = {path.as_posix() for path, _ in plan.files_to_write}
-    copied_paths = {path.as_posix() for path, _ in plan.files_to_copy}
-    symlinked_paths = {path.as_posix() for path, _ in plan.files_to_symlink}
-    file_count = len(written_paths | copied_paths | symlinked_paths)
+    log_progress("hydrate", "file", "done", count=file_count)
     return HydrateResult(
         context_dir=str(plan.context_dir),
         component_count=plan.component_count,
@@ -181,9 +180,7 @@ def build_inline_hydration_plan(
     cache_ttl: timedelta | None = None,
     refresh_cache: bool = False,
     plugin_overrides: dict[str, Any] | None = None,
-    target_depth: int = 0,
-    target_scope: str = "all",
-    include_parent: bool = True,
+    embedded_resolution: bool = False,
 ) -> HydratePlan:
     from ..utils import brace_expand
 
@@ -229,9 +226,7 @@ def build_inline_hydration_plan(
             refresh_cache=refresh_cache,
             plugin_overrides=plugin_overrides,
             local_base=local_base,
-            target_depth=target_depth,
-            target_scope=target_scope,
-            include_parent=include_parent,
+            embedded_resolution=embedded_resolution,
         )
         for item in items:
             subpath = _split_subpath(item.context_subpath)
@@ -433,20 +428,12 @@ def build_hydration_plan_data(
 
     base_dir = _resolve_base_dir(cfg, manifest_cwd, manifest_path)
     context_cfg = _resolve_context_config(cfg, overrides, cwd)
-    target_depth_default = int(
-        overrides.target_depth
-        if overrides.target_depth is not None
-        else cfg.get("target-depth", 0) or 0
-    )
-    target_scope_default = _normalize_target_scope(
-        overrides.target_scope or cfg.get("target-scope", "all") or "all",
-        label="target-scope",
-    )
-    include_parent_default = _normalize_bool(
-        overrides.include_parent
-        if overrides.include_parent is not None
-        else cfg.get("include-parent", True),
-        label="include-parent",
+    _reject_removed_embedded_traversal_keys(cfg, "config")
+    embedded_resolution_default = _normalize_bool(
+        overrides.embedded_resolution
+        if overrides.embedded_resolution is not None
+        else cfg.get("embedded-resolution", False),
+        label="embedded-resolution",
     )
     context_dir = context_cfg["dir"]
     has_local_sources = _manifest_has_local_sources(components)
@@ -477,8 +464,10 @@ def build_hydration_plan_data(
             context_cfg["agents_text"],
         )
 
+    log_progress("hydrate", "component", "total", count=len(components))
     for comp in components:
         comp_name = comp["name"]
+        log_progress("hydrate", "component", "start", target=comp_name)
         comp_files = comp.get("files")
         comp_repos = comp.get("repos")
         comp_text = comp.get("text")
@@ -501,14 +490,10 @@ def build_hydration_plan_data(
             comp,
             prefix=f"component '{comp_name}'",
         )
-        comp_target_depth = int(comp.get("target-depth", target_depth_default) or 0)
-        comp_target_scope = _normalize_target_scope(
-            comp.get("target-scope", target_scope_default) or "all",
-            label=f"Component '{comp_name}' target-scope",
-        )
-        comp_include_parent = _normalize_bool(
-            comp.get("include-parent", include_parent_default),
-            label=f"Component '{comp_name}' include-parent",
+        _reject_removed_embedded_traversal_keys(comp, f"component '{comp_name}'")
+        comp_embedded_resolution = _normalize_bool(
+            comp.get("embedded-resolution", embedded_resolution_default),
+            label=f"Component '{comp_name}' embedded-resolution",
         )
 
         if (
@@ -571,8 +556,6 @@ def build_hydration_plan_data(
                     Any | None,
                     bool,
                     dict[str, Any] | None,
-                    int,
-                    str,
                     bool,
                 ],
             ] = {}
@@ -601,16 +584,12 @@ def build_hydration_plan_data(
                 plugin_overrides_key = _plugin_overrides_cache_key(
                     effective_plugin_overrides
                 )
-                file_target_depth = int(
-                    file_opts.get("target-depth", comp_target_depth) or 0
+                _reject_removed_embedded_traversal_keys(
+                    file_opts, f"Component '{comp_name}' file[{spec_index}]"
                 )
-                file_target_scope = _normalize_target_scope(
-                    file_opts.get("target-scope", comp_target_scope) or "all",
-                    label=f"Component '{comp_name}' file[{spec_index}] target-scope",
-                )
-                file_include_parent = _normalize_bool(
-                    file_opts.get("include-parent", comp_include_parent),
-                    label=f"Component '{comp_name}' file[{spec_index}] include-parent",
+                file_embedded_resolution = _normalize_bool(
+                    file_opts.get("embedded-resolution", comp_embedded_resolution),
+                    label=f"Component '{comp_name}' file[{spec_index}] embedded-resolution",
                 )
 
                 alias_hint = file_opts.get("alias") or file_opts.get("filename")
@@ -621,9 +600,7 @@ def build_hydration_plan_data(
                     comp_gitignore,
                     cache_alias,
                     plugin_overrides_key,
-                    file_target_depth,
-                    file_target_scope,
-                    file_include_parent,
+                    file_embedded_resolution,
                 )
                 if (
                     spec_cache_key not in resolved_spec_cache
@@ -634,9 +611,7 @@ def build_hydration_plan_data(
                         alias_hint,
                         force_git,
                         effective_plugin_overrides,
-                        file_target_depth,
-                        file_target_scope,
-                        file_include_parent,
+                        file_embedded_resolution,
                     )
 
                 prepared_specs.append(
@@ -654,7 +629,7 @@ def build_hydration_plan_data(
                 (
                     index,
                     (
-                        lambda rs=raw_spec, ah=alias_hint, fg=force_git, epo=effective_plugin_overrides, td=target_depth, ts=target_scope, ip=include_parent: (
+                        lambda rs=raw_spec, ah=alias_hint, fg=force_git, epo=effective_plugin_overrides, er=embedded_resolution: (
                             _resolve_spec_items(
                                 rs,
                                 base_dir,
@@ -666,9 +641,7 @@ def build_hydration_plan_data(
                                 refresh_cache=context_cfg["refresh_cache"],
                                 force_git=fg,
                                 plugin_overrides=epo,
-                                target_depth=td,
-                                target_scope=ts,
-                                include_parent=ip,
+                                embedded_resolution=er,
                             )
                         )
                     ),
@@ -680,9 +653,7 @@ def build_hydration_plan_data(
                         alias_hint,
                         force_git,
                         effective_plugin_overrides,
-                        target_depth,
-                        target_scope,
-                        include_parent,
+                        embedded_resolution,
                     ),
                 ) in enumerate(pending_by_key.items())
             ]
@@ -856,6 +827,31 @@ def build_hydration_plan_data(
         if normalized_files:
             normalized_comp["files"] = _dedupe_manifest_entries(normalized_files)
         normalized_components.append(normalized_comp)
+        log_progress(
+            "hydrate",
+            "component",
+            "done",
+            target=comp_name,
+            count=len(normalized_files),
+        )
+
+    skipped_plugin_paths = _materialize_plugin_pending(
+        plugin_pending,
+        context_dir,
+        files_to_write,
+        files_to_copy,
+        files_to_symlink,
+        file_timestamps,
+    )
+    if skipped_plugin_paths:
+        index_components = {
+            component: [
+                entry
+                for entry in entries
+                if entry.get("context_path") not in skipped_plugin_paths
+            ]
+            for component, entries in index_components.items()
+        }
 
     if context_cfg["include_meta"]:
         normalized_manifest = {
@@ -879,15 +875,6 @@ def build_hydration_plan_data(
         index_data = {"version": 1, "components": index_components}
         index_text = _dump_index(index_data)
         files_to_write.append((context_dir / "index.json", index_text))
-
-    _materialize_plugin_pending(
-        plugin_pending,
-        context_dir,
-        files_to_write,
-        files_to_copy,
-        files_to_symlink,
-        file_timestamps,
-    )
 
     return HydratePlan(
         context_dir=context_dir,
@@ -999,13 +986,16 @@ def _resolve_context_config(
     }
 
 
-def _normalize_target_scope(value: Any, *, label: str) -> str:
-    if not isinstance(value, str):
-        raise ValueError(f"{label} must be a string")
-    normalized = value.lower()
-    if normalized not in {"first", "all"}:
-        raise ValueError(f"{label} must be 'first' or 'all'")
-    return normalized
+def _reject_removed_embedded_traversal_keys(mapping: dict[str, Any], label: str) -> None:
+    removed = [
+        key for key in ("target-depth", "target-scope", "include-parent") if key in mapping
+    ]
+    if not removed:
+        return
+    keys = ", ".join(removed)
+    raise ValueError(
+        f"{label} uses removed embedded traversal key(s): {keys}. Use embedded-resolution instead."
+    )
 
 
 def _normalize_bool(value: Any, *, label: str) -> bool:
@@ -1188,10 +1178,7 @@ def _manifest_plugin_providers(components: list[dict[str, Any]]) -> set[str]:
             continue
         for file_spec in files:
             raw_spec, _ = coerce_file_spec(file_spec)
-            descriptor = classify_plugin_target(_plugin_target_from_spec(raw_spec))
-            if not isinstance(descriptor, dict):
-                continue
-            provider = descriptor.get("provider")
+            provider = plugin_target_provider(_plugin_target_from_spec(raw_spec))
             if isinstance(provider, str) and provider:
                 providers.add(provider)
     return providers
@@ -1374,7 +1361,7 @@ def _is_external_spec(raw_spec: str) -> bool:
     target = parse_target_spec(spec).get("target", spec)
     if not isinstance(target, str):
         target = spec
-    if classify_plugin_target(target) is not None:
+    if plugin_target_provider(target) is not None:
         return True
     if is_http_url(target):
         return True
@@ -1470,6 +1457,85 @@ def _ensure_markdown_suffix(path: str) -> str:
     return f"{path}.md"
 
 
+def _context_prefix_from_metadata(metadata: dict[str, Any]) -> str | None:
+    raw_prefix = metadata.get("context_prefix")
+    if not isinstance(raw_prefix, str):
+        return None
+    return _normalize_context_prefix(raw_prefix)
+
+
+def _context_sidecar_stem_from_metadata(metadata: dict[str, Any]) -> str | None:
+    raw_stem = metadata.get("context_sidecar_stem")
+    if not isinstance(raw_stem, str):
+        return None
+    return _normalize_context_prefix(raw_stem)
+
+
+def _context_prefix_from_ref(ref: Any) -> str | None:
+    raw_prefix = getattr(ref, "_contextualize_context_prefix", None)
+    if not isinstance(raw_prefix, str):
+        return None
+    return _normalize_context_prefix(raw_prefix)
+
+
+def _context_sidecar_stem_from_ref(ref: Any) -> str | None:
+    raw_stem = getattr(ref, "_contextualize_context_sidecar_stem", None)
+    if not isinstance(raw_stem, str):
+        return None
+    return _normalize_context_prefix(raw_stem)
+
+
+def _normalize_context_prefix(value: str) -> str | None:
+    raw = value.strip().strip("/")
+    if not raw:
+        return None
+    parts = [part for part in raw.split("/") if part and part not in {".", ".."}]
+    return "/".join(parts) or None
+
+
+def _join_context_subpath(prefix: str | None, subpath: str) -> str:
+    clean_prefix = _normalize_context_prefix(prefix) if prefix else None
+    clean_subpath = _normalize_context_prefix(subpath) or "index"
+    if clean_prefix:
+        return f"{clean_prefix}/{clean_subpath}"
+    return clean_subpath
+
+
+def _plugin_slug_from_source_type(source_type: str | None) -> str | None:
+    if not source_type or not source_type.startswith("plugin:"):
+        return None
+    return _sanitize_path_segment(
+        source_type.replace("plugin:", "", 1), fallback="plugin"
+    )
+
+
+def _sidecar_context_subpath(
+    stem: str | None,
+    subpath: str,
+    *,
+    source_type: str | None = None,
+) -> str:
+    clean_stem = _normalize_context_prefix(stem) if stem else None
+    if clean_stem is None:
+        return _join_context_subpath(None, subpath)
+    if clean_stem.endswith(".md"):
+        clean_stem = clean_stem[:-3]
+
+    clean_subpath = _normalize_context_prefix(subpath) or "item"
+    leaf = Path(clean_subpath).name or "item"
+    if leaf.endswith(".md"):
+        leaf = leaf[:-3]
+    sidecar = _sanitize_path_segment(leaf, fallback="item")
+    plugin_slug = _plugin_slug_from_source_type(source_type)
+    if (
+        plugin_slug is not None
+        and not sidecar.startswith(f"{plugin_slug}-")
+        and not (plugin_slug == "arena" and sidecar.startswith("attachment-"))
+    ):
+        sidecar = f"{plugin_slug}-{sidecar}"
+    return f"{clean_stem}.{sidecar}.md"
+
+
 def _plugin_context_subpath(
     *,
     metadata: dict[str, Any],
@@ -1497,24 +1563,30 @@ def _plugin_context_subpath(
             base = f"{plugin_slug}/{fallback_name}.md"
     base = _ensure_markdown_suffix(base)
     alias_prefix = _plugin_alias_prefix(alias, fallback="plugin")
-    if alias_prefix is None:
-        return base
-
-    if total_refs == 1:
-        suffix = Path(base).suffix or ".md"
-        return f"{alias_prefix}{suffix}"
-    return f"{alias_prefix}/{base}"
+    if alias_prefix is not None:
+        if total_refs == 1:
+            suffix = Path(base).suffix or ".md"
+            base = f"{alias_prefix}{suffix}"
+        else:
+            base = f"{alias_prefix}/{base}"
+    sidecar_stem = _context_sidecar_stem_from_metadata(metadata)
+    if sidecar_stem is not None:
+        return _sidecar_context_subpath(
+            sidecar_stem, base, source_type=source_type
+        )
+    return _join_context_subpath(_context_prefix_from_metadata(metadata), base)
 
 
 def _plugin_dedupe_fields(
     metadata: dict[str, Any],
-) -> tuple[str | None, str | None, int | None]:
+) -> tuple[str | None, str | None, int | None, bool]:
     dedupe = metadata.get("hydrate_dedupe")
     if not isinstance(dedupe, dict):
-        return None, None, None
+        return None, None, None, True
     mode_raw = dedupe.get("mode")
     key_raw = dedupe.get("key")
     rank_raw = dedupe.get("rank")
+    link_raw = dedupe.get("link")
     mode = mode_raw.strip() if isinstance(mode_raw, str) else None
     key = key_raw.strip() if isinstance(key_raw, str) else None
     rank: int | None = None
@@ -1525,7 +1597,8 @@ def _plugin_dedupe_fields(
             rank = int(rank_raw.strip())
         except ValueError:
             rank = None
-    return mode, key, rank
+    link = link_raw if isinstance(link_raw, bool) else True
+    return mode, key, rank, link
 
 
 def _resolve_external_items_via_refs(
@@ -1536,9 +1609,7 @@ def _resolve_external_items_via_refs(
     cache_ttl: timedelta | None = None,
     refresh_cache: bool = False,
     plugin_overrides: dict[str, Any] | None = None,
-    target_depth: int = 0,
-    target_scope: str = "all",
-    include_parent: bool = True,
+    embedded_resolution: bool = False,
 ) -> list[ResolvedItem]:
     refs = create_file_references(
         [target],
@@ -1549,9 +1620,7 @@ def _resolve_external_items_via_refs(
         cache_ttl=cache_ttl,
         refresh_cache=refresh_cache,
         plugin_overrides=plugin_overrides,
-        target_depth=target_depth,
-        target_scope=target_scope,
-        include_parent=include_parent,
+        embedded_resolution=embedded_resolution,
     )["refs"]
 
     plugin_refs = [ref for ref in refs if isinstance(ref, PluginReference)]
@@ -1579,7 +1648,9 @@ def _resolve_external_items_via_refs(
                 alias=alias,
                 total_refs=plugin_count if plugin_count > 0 else len(refs),
             )
-            dedupe_mode, dedupe_key, dedupe_rank = _plugin_dedupe_fields(metadata)
+            dedupe_mode, dedupe_key, dedupe_rank, dedupe_link = (
+                _plugin_dedupe_fields(metadata)
+            )
             items.append(
                 ResolvedItem(
                     source_type=source_type,
@@ -1607,13 +1678,27 @@ def _resolve_external_items_via_refs(
                     plugin_dedupe_mode=dedupe_mode,
                     plugin_dedupe_key=dedupe_key,
                     plugin_dedupe_rank=dedupe_rank,
+                    plugin_dedupe_link=dedupe_link,
                 )
             )
             continue
 
-        if is_http_url(target):
-            origin, url_path = _split_url_path(target)
+        ref_path_raw = getattr(ref, "path", None) or getattr(ref, "url", None)
+        ref_content = getattr(ref, "file_content", None)
+        ref_context_prefix = _context_prefix_from_ref(ref)
+        ref_sidecar_stem = _context_sidecar_stem_from_ref(ref)
+        http_target = ref_path_raw if isinstance(ref_path_raw, str) else target
+        if is_http_url(http_target):
+            origin, url_path = _split_url_path(http_target)
             context_path = _apply_filename_hint(url_path, alias)
+            if ref_sidecar_stem is not None:
+                context_path = _sidecar_context_subpath(
+                    ref_sidecar_stem, context_path
+                )
+            else:
+                context_path = _join_context_subpath(
+                    ref_context_prefix, context_path
+                )
             items.append(
                 ResolvedItem(
                     source_type="http",
@@ -1622,25 +1707,33 @@ def _resolve_external_items_via_refs(
                     source_path=url_path,
                     context_subpath=context_path,
                     content=ref.file_content,
-                    manifest_spec=target,
+                    manifest_spec=http_target,
                     alias=alias if isinstance(alias, str) else None,
                 )
             )
             continue
-        ref_path_raw = getattr(ref, "path", None) or getattr(ref, "url", None)
-        ref_content = getattr(ref, "file_content", None)
         if isinstance(ref_path_raw, str) and isinstance(ref_content, str):
             source_path = Path(ref_path_raw).name or "item"
             context_path = _apply_filename_hint(source_path, alias)
+            if ref_sidecar_stem is not None:
+                context_path = _sidecar_context_subpath(
+                    ref_sidecar_stem,
+                    context_path,
+                    source_type="plugin:materialized",
+                )
+            else:
+                context_path = _join_context_subpath(
+                    ref_context_prefix, context_path
+                )
             items.append(
                 ResolvedItem(
                     source_type="plugin:materialized",
-                    source_ref=target,
+                    source_ref=ref_path_raw,
                     source_rev=None,
                     source_path=source_path,
                     context_subpath=context_path,
                     content=ref_content,
-                    manifest_spec=target,
+                    manifest_spec=ref_path_raw,
                     alias=alias if isinstance(alias, str) else None,
                     plugin_name="materialized",
                 )
@@ -1706,9 +1799,7 @@ def _resolve_spec_items(
     force_git: bool = False,
     plugin_overrides: dict[str, Any] | None = None,
     local_base: str | None = None,
-    target_depth: int = 0,
-    target_scope: str = "all",
-    include_parent: bool = True,
+    embedded_resolution: bool = False,
 ) -> list[ResolvedItem]:
     spec = os.path.expanduser(raw_spec)
     spec_opts = parse_target_spec(spec)
@@ -1772,9 +1863,7 @@ def _resolve_spec_items(
             cache_ttl=cache_ttl,
             refresh_cache=refresh_cache,
             plugin_overrides=plugin_overrides,
-            target_depth=target_depth,
-            target_scope=target_scope,
-            include_parent=include_parent,
+            embedded_resolution=embedded_resolution,
         )
 
     tgt = parse_git_target(target)
@@ -1789,9 +1878,7 @@ def _resolve_spec_items(
             cache_ttl=cache_ttl,
             refresh_cache=refresh_cache,
             plugin_overrides=plugin_overrides,
-            target_depth=target_depth,
-            target_scope=target_scope,
-            include_parent=include_parent,
+            embedded_resolution=embedded_resolution,
         )
 
     base = "" if os.path.isabs(target) else base_dir
@@ -2282,12 +2369,11 @@ def _build_manifest_file_entry(
     comment: str | None,
     extras: dict[str, Any],
 ) -> dict[str, Any] | str:
-    plugin_target = classify_plugin_target(item.manifest_spec)
     is_url = (
         item.source_type == "http"
         or item.source_type.startswith("plugin:")
         or is_http_url(item.manifest_spec)
-        or plugin_target is not None
+        or plugin_target_provider(item.manifest_spec) is not None
     )
     key = "url" if is_url else "path"
     entry = {key: item.manifest_spec}
@@ -2361,7 +2447,8 @@ def _materialize_plugin_pending(
     files_to_copy: list[tuple[Path, Path]],
     files_to_symlink: list[tuple[Path, Path]],
     file_timestamps: dict[Path, tuple[float, float]],
-) -> None:
+) -> set[str]:
+    skipped_paths: set[str] = set()
     for occurrences in plugin_pending.values():
         canonical = min(
             occurrences,
@@ -2392,7 +2479,11 @@ def _materialize_plugin_pending(
         for occ in occurrences:
             if occ.rel_path == canonical.rel_path:
                 continue
-            files_to_symlink.append((context_dir / occ.rel_path, canonical_path))
+            if occ.item.plugin_dedupe_link:
+                files_to_symlink.append((context_dir / occ.rel_path, canonical_path))
+            else:
+                skipped_paths.add(occ.rel_path.as_posix())
+    return skipped_paths
 
 
 def _dedupe_manifest_entries(files: list[Any]) -> list[Any]:
@@ -2562,22 +2653,32 @@ def _apply_timestamps(timestamps: dict[Path, tuple[float, float]]) -> None:
             pass
 
 
+def _hydration_file_count(plan: HydratePlan) -> int:
+    written_paths = {path.as_posix() for path, _ in plan.files_to_write}
+    copied_paths = {path.as_posix() for path, _ in plan.files_to_copy}
+    symlinked_paths = {path.as_posix() for path, _ in plan.files_to_symlink}
+    return len(written_paths | copied_paths | symlinked_paths)
+
+
 def _write_files(files: list[tuple[Path, str]]) -> None:
     for path, content in files:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
+        log_progress("hydrate", "file", "processed", target=str(path))
 
 
 def _copy_files(files: list[tuple[Path, Path]]) -> None:
     for dest, source in files:
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, dest)
+        log_progress("hydrate", "file", "processed", target=str(dest))
 
 
 def _create_symlinks(links: list[tuple[Path, Path]]) -> None:
     for dest, source in links:
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.symlink_to(source.resolve())
+        log_progress("hydrate", "file", "processed", target=str(dest))
 
 
 def _apply_read_only(root: Path) -> None:

--- a/src/contextualize/manifest/payload.py
+++ b/src/contextualize/manifest/payload.py
@@ -31,9 +31,7 @@ def build_payload(
     link_depth: int = 0,
     link_scope: str = "all",
     link_skip: list[str] | None = None,
-    target_depth: int = 0,
-    target_scope: str = "all",
-    include_parent: bool = True,
+    embedded_resolution: bool = False,
     exclude_keys: list[str] | None = None,
     map_mode: bool = False,
     map_keys: list[str] | None = None,
@@ -51,9 +49,7 @@ def build_payload(
         link_depth_default=link_depth,
         link_scope_default=link_scope,
         link_skip_default=link_skip or [],
-        target_depth_default=target_depth,
-        target_scope_default=target_scope,
-        include_parent_default=include_parent,
+        embedded_resolution_default=embedded_resolution,
         exclude_keys=exclude_keys,
         map_mode=map_mode,
         map_keys=map_keys,
@@ -74,8 +70,6 @@ def _prepare_manifest_payload(
     int,
     str,
     list[str],
-    int,
-    str,
     bool,
     timedelta | None,
 ]:
@@ -99,13 +93,17 @@ def _prepare_manifest_payload(
     elif isinstance(link_skip_default, str):
         link_skip_default = [link_skip_default]
 
-    target_depth_default = int(cfg.get("target-depth", 0) or 0)
-    target_scope_default = (cfg.get("target-scope", "all") or "all").lower()
-    if target_scope_default not in {"first", "all"}:
-        raise ValueError("target-scope must be 'first' or 'all'")
-    include_parent_default = cfg.get("include-parent", True)
-    if not isinstance(include_parent_default, bool):
-        raise ValueError("include-parent must be a boolean")
+    removed = [
+        key for key in ("target-depth", "target-scope", "include-parent") if key in cfg
+    ]
+    if removed:
+        keys = ", ".join(removed)
+        raise ValueError(
+            f"config uses removed embedded traversal key(s): {keys}. Use embedded-resolution instead."
+        )
+    embedded_resolution_default = cfg.get("embedded-resolution", False)
+    if not isinstance(embedded_resolution_default, bool):
+        raise ValueError("embedded-resolution must be a boolean")
 
     context_cfg = cfg.get("context", {})
     raw_ttl = context_cfg.get("cache-ttl") if isinstance(context_cfg, dict) else None
@@ -124,9 +122,7 @@ def _prepare_manifest_payload(
         link_depth_default,
         link_scope_default,
         link_skip_default,
-        target_depth_default,
-        target_scope_default,
-        include_parent_default,
+        embedded_resolution_default,
         manifest_cache_ttl,
     )
 
@@ -152,9 +148,7 @@ def render_manifest(
       - link-depth: default depth for Markdown link traversal
       - link-scope: "first" or "all" (default: all)
       - link-skip: list of paths to skip when resolving Markdown links
-      - target-depth: default depth for embedded plugin target traversal
-      - target-scope: "first" or "all" (default: all)
-      - include-parent: include original targets when resolving embedded targets
+      - embedded-resolution: resolve plugin targets attached to collected items
       - context.cache-ttl: default cache TTL for URL content
     """
     source = load_manifest_source(manifest_path)
@@ -166,9 +160,7 @@ def render_manifest(
         link_depth_default,
         link_scope_default,
         link_skip_default,
-        target_depth_default,
-        target_scope_default,
-        include_parent_default,
+        embedded_resolution_default,
         manifest_cache_ttl,
     ) = _prepare_manifest_payload(data, base_dir_default)
 
@@ -182,9 +174,7 @@ def render_manifest(
         link_depth=link_depth_default,
         link_scope=link_scope_default,
         link_skip=link_skip_default,
-        target_depth=target_depth_default,
-        target_scope=target_scope_default,
-        include_parent=include_parent_default,
+        embedded_resolution=embedded_resolution_default,
         exclude_keys=exclude_keys,
         map_mode=map_mode,
         map_keys=map_keys,
@@ -220,9 +210,7 @@ def render_manifest_data(
         link_depth_default,
         link_scope_default,
         link_skip_default,
-        target_depth_default,
-        target_scope_default,
-        include_parent_default,
+        embedded_resolution_default,
         manifest_cache_ttl,
     ) = _prepare_manifest_payload(data, manifest_cwd)
 
@@ -236,9 +224,7 @@ def render_manifest_data(
         link_depth=link_depth_default,
         link_scope=link_scope_default,
         link_skip=link_skip_default,
-        target_depth=target_depth_default,
-        target_scope=target_scope_default,
-        include_parent=include_parent_default,
+        embedded_resolution=embedded_resolution_default,
         exclude_keys=exclude_keys,
         map_mode=map_mode,
         map_keys=map_keys,

--- a/src/contextualize/plugins/__init__.py
+++ b/src/contextualize/plugins/__init__.py
@@ -10,6 +10,7 @@ from .resolve import (
     list_plugin_targets,
     loaded_plugin_names,
     normalize_manifest_plugin_config,
+    plugin_target_provider,
     resolve_plugin_references,
 )
 
@@ -20,6 +21,7 @@ __all__ = [
     "classify_plugin_target",
     "list_plugin_targets",
     "normalize_manifest_plugin_config",
+    "plugin_target_provider",
     "loaded_plugin_names",
     "sync_plugin_cli_commands",
     "collect_plugin_cli_overrides",

--- a/src/contextualize/plugins/resolve.py
+++ b/src/contextualize/plugins/resolve.py
@@ -574,6 +574,31 @@ def normalize_manifest_plugin_config(
     return dict(normalized)
 
 
+def plugin_target_provider(
+    target: str,
+    *,
+    overrides: dict[str, Any] | None = None,
+    use_cache: bool = True,
+    cache_ttl: timedelta | None = None,
+    refresh_cache: bool = False,
+) -> str | None:
+    context = _build_inspection_context(
+        overrides,
+        use_cache=use_cache,
+        cache_ttl=cache_ttl,
+        refresh_cache=refresh_cache,
+    )
+    for plugin in get_loaded_plugins():
+        try:
+            matched = bool(plugin.can_resolve(target, context))
+        except Exception as exc:
+            _warn(f"plugin '{plugin.name}' can_resolve failed for '{target}': {exc}")
+            continue
+        if matched:
+            return plugin.name
+    return None
+
+
 def classify_plugin_target(
     target: str,
     *,

--- a/src/contextualize/progress.py
+++ b/src/contextualize/progress.py
@@ -1,0 +1,483 @@
+from __future__ import annotations
+
+from collections import Counter
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import sys
+import threading
+from typing import Any
+
+
+_CURRENT_CONTEXT: ContextVar[str | None] = ContextVar(
+    "contextualize_progress_context", default=None
+)
+_EVENTS: list["ProgressEvent"] = []
+_LOCK = threading.Lock()
+_LIVE_LOCK = threading.Lock()
+_LIVE_REPORTER: "_RichProgressReporter | None" = None
+
+
+@dataclass(frozen=True)
+class ProgressEvent:
+    provider: str
+    operation: str
+    outcome: str
+    target: str | None = None
+    detail: str | None = None
+    count: int | None = None
+    size_bytes: int | None = None
+    context: str | None = None
+    timestamp: str = ""
+
+
+def reset_progress() -> None:
+    with _LOCK:
+        _EVENTS.clear()
+    reporter = _current_reporter()
+    if reporter is not None:
+        reporter.reset()
+
+
+def set_live_progress(
+    enabled: bool,
+    *,
+    force_terminal: bool | None = None,
+    transient: bool = False,
+) -> None:
+    global _LIVE_REPORTER
+    reporter_to_stop: _RichProgressReporter | None = None
+    with _LIVE_LOCK:
+        if enabled:
+            if _LIVE_REPORTER is not None:
+                return
+            reporter = _RichProgressReporter(
+                force_terminal=force_terminal,
+                transient=transient,
+            )
+            if reporter.start():
+                _LIVE_REPORTER = reporter
+            return
+        reporter_to_stop = _LIVE_REPORTER
+        _LIVE_REPORTER = None
+    if reporter_to_stop is not None:
+        reporter_to_stop.stop()
+
+
+def write_progress_log(line: str) -> bool:
+    reporter = _current_reporter()
+    if reporter is None:
+        return False
+    reporter.write(line)
+    return True
+
+
+def live_progress_active() -> bool:
+    return _current_reporter() is not None
+
+
+def set_progress_context(name: str | None) -> Token[str | None]:
+    value = name.strip() if isinstance(name, str) and name.strip() else None
+    return _CURRENT_CONTEXT.set(value)
+
+
+def reset_progress_context(token: Token[str | None]) -> None:
+    _CURRENT_CONTEXT.reset(token)
+
+
+def record_progress(
+    provider: str,
+    operation: str,
+    outcome: str,
+    *,
+    target: str | None = None,
+    detail: str | None = None,
+    count: int | None = None,
+    size_bytes: int | None = None,
+) -> None:
+    event = ProgressEvent(
+        provider=_normalize(provider, "unknown"),
+        operation=_normalize(operation, "operation"),
+        outcome=_normalize(outcome, "event"),
+        target=_clean_optional(target),
+        detail=_clean_optional(detail),
+        count=count if isinstance(count, int) else None,
+        size_bytes=size_bytes if isinstance(size_bytes, int) else None,
+        context=_CURRENT_CONTEXT.get(),
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
+    with _LOCK:
+        _EVENTS.append(event)
+    reporter = _current_reporter()
+    if reporter is not None:
+        reporter.record(event)
+
+
+def log_progress(
+    provider: str,
+    operation: str,
+    outcome: str,
+    *,
+    target: str | None = None,
+    detail: str | None = None,
+    count: int | None = None,
+    size_bytes: int | None = None,
+) -> None:
+    record_progress(
+        provider,
+        operation,
+        outcome,
+        target=target,
+        detail=detail,
+        count=count,
+        size_bytes=size_bytes,
+    )
+
+
+def progress_summary_lines() -> list[str]:
+    with _LOCK:
+        events = list(_EVENTS)
+    if not events:
+        return []
+
+    groups: dict[tuple[str | None, str, str], list[ProgressEvent]] = {}
+    for event in events:
+        key = (event.context, event.provider, event.operation)
+        groups.setdefault(key, []).append(event)
+    lines = ["Progress summary:"]
+    current_context: str | None | object = object()
+    for (context, provider, operation), group_events in sorted(
+        groups.items(),
+        key=lambda item: (
+            item[0][0] or "",
+            item[0][1],
+            item[0][2],
+        ),
+    ):
+        parts = _summary_parts(group_events)
+        if not parts:
+            continue
+        if context != current_context:
+            current_context = context
+            if context:
+                lines.append(f"  context {context}:")
+        prefix = "    " if context else "  "
+        lines.append(f"{prefix}{provider} {operation}: {' '.join(parts)}")
+    return lines
+
+
+def flush_progress_summary(*, enabled: bool) -> None:
+    if not enabled:
+        return
+    lines = progress_summary_lines()
+    if not lines:
+        return
+    print("\n".join(lines), file=sys.stderr, flush=True)
+
+
+def _current_reporter() -> "_RichProgressReporter | None":
+    with _LIVE_LOCK:
+        return _LIVE_REPORTER
+
+
+@dataclass
+class _LiveTaskState:
+    task_id: Any
+    total: int | None = None
+    completed: int = 0
+    counts: Counter[str] | None = None
+    item_count: int = 0
+    byte_count: int = 0
+    latest: str = ""
+
+    def __post_init__(self) -> None:
+        if self.counts is None:
+            self.counts = Counter()
+
+
+class _RichProgressReporter:
+    def __init__(self, *, force_terminal: bool | None, transient: bool) -> None:
+        self.force_terminal = force_terminal
+        self.transient = transient
+        self._lock = threading.Lock()
+        self._progress: Any = None
+        self._tasks: dict[tuple[str | None, str, str], _LiveTaskState] = {}
+
+    def start(self) -> bool:
+        if self.force_terminal is not True and not sys.stderr.isatty():
+            return False
+        try:
+            from rich.console import Console
+            from rich.progress import BarColumn
+            from rich.progress import Progress
+            from rich.progress import SpinnerColumn
+            from rich.progress import TextColumn
+            from rich.progress import TimeElapsedColumn
+            from rich.progress import TimeRemainingColumn
+        except ImportError:
+            return False
+
+        console = Console(
+            file=sys.stderr,
+            stderr=True,
+            force_terminal=self.force_terminal,
+        )
+        self._progress = Progress(
+            SpinnerColumn(),
+            TextColumn("{task.description}"),
+            BarColumn(bar_width=None),
+            TextColumn("{task.fields[units]}", justify="right"),
+            TextColumn("{task.fields[stats]}"),
+            TimeElapsedColumn(),
+            TimeRemainingColumn(),
+            console=console,
+            transient=self.transient,
+            redirect_stderr=True,
+            redirect_stdout=False,
+            refresh_per_second=8,
+        )
+        self._progress.start()
+        return True
+
+    def stop(self) -> None:
+        progress = self._progress
+        if progress is None:
+            return
+        with self._lock:
+            self._progress = None
+            self._tasks.clear()
+        progress.stop()
+
+    def reset(self) -> None:
+        with self._lock:
+            if self._progress is not None:
+                for task in self._tasks.values():
+                    self._progress.remove_task(task.task_id)
+            self._tasks.clear()
+
+    def write(self, line: str) -> None:
+        progress = self._progress
+        if progress is None:
+            return
+        text = str(line)
+        if not text:
+            return
+        with self._lock:
+            for part in text.splitlines() or [text]:
+                progress.console.print(part, markup=False)
+
+    def record(self, event: ProgressEvent) -> None:
+        progress = self._progress
+        if progress is None:
+            return
+        key = _task_key(event)
+        with self._lock:
+            state = self._tasks.get(key)
+            if state is None:
+                state = self._add_task(event)
+                self._tasks[key] = state
+            self._apply_event(state, event)
+            progress.update(
+                state.task_id,
+                total=state.total,
+                completed=state.completed,
+                units=_format_units(state),
+                stats=_format_task_stats(state),
+            )
+
+    def _add_task(self, event: ProgressEvent) -> _LiveTaskState:
+        task_id = self._progress.add_task(
+            _task_description(event),
+            total=None,
+            units="events 0",
+            stats="",
+        )
+        return _LiveTaskState(task_id=task_id)
+
+    def _apply_event(self, state: _LiveTaskState, event: ProgressEvent) -> None:
+        if event.outcome == "total":
+            state.total = max(event.count or 0, 0)
+            state.completed = 0
+        elif event.outcome == "start":
+            target_total = _target_total_from_detail(event.detail)
+            if target_total is not None:
+                state.total = target_total
+                state.completed = 0
+                state.counts = Counter()
+                state.item_count = 0
+                state.byte_count = 0
+                state.latest = ""
+        elif event.outcome == "done":
+            if event.operation in {"embedded-list", "embedded-resolve"}:
+                state.completed = state.total or state.completed
+            else:
+                state.completed += 1
+        elif event.outcome in {"processed", "cache_hit", "cache_miss", "failed"}:
+            state.completed += 1
+
+        if state.total is not None:
+            state.completed = min(state.completed, state.total)
+
+        if event.outcome not in {"total", "start"} and not (
+            event.provider == "hydrate"
+            and event.operation == "file"
+            and event.outcome == "done"
+        ):
+            assert state.counts is not None
+            state.counts[event.outcome] += 1
+        if event.count is not None and event.outcome not in {"total", "done"}:
+            state.item_count += event.count
+        if event.size_bytes is not None:
+            state.byte_count += event.size_bytes
+        state.latest = _format_event_target(event)
+
+
+def _task_key(event: ProgressEvent) -> tuple[str | None, str, str]:
+    operation = "files" if event.operation == "file" else event.operation
+    return (event.context, event.provider, operation)
+
+
+def _summary_parts(events: list[ProgressEvent]) -> list[str]:
+    total_value: int | None = None
+    counters: Counter[str] = Counter()
+    item_count = 0
+    byte_count = 0
+    start_count = 0
+    for event in events:
+        if event.outcome == "total":
+            total_value = event.count
+            continue
+        if event.outcome == "start":
+            start_count += 1
+            continue
+        if not (
+            event.provider == "hydrate"
+            and event.operation == "file"
+            and event.outcome == "done"
+        ):
+            counters[event.outcome] += 1
+        if event.count is not None and event.outcome != "done":
+            item_count += event.count
+        if event.size_bytes is not None:
+            byte_count += event.size_bytes
+
+    parts: list[str] = []
+    if total_value is not None:
+        parts.append(f"total={total_value}")
+    for outcome in _ordered_outcomes(counters):
+        parts.append(f"{outcome}={counters[outcome]}")
+    if item_count:
+        parts.append(f"items={item_count}")
+    if byte_count:
+        parts.append(f"bytes={_format_bytes(byte_count)}")
+    if not parts and start_count:
+        parts.append(f"start={start_count}")
+    return parts
+
+
+def _ordered_outcomes(counters: Counter[str]) -> list[str]:
+    preferred = [
+        "cache_hit",
+        "cache_miss",
+        "processed",
+        "failed",
+        "done",
+    ]
+    ordered = [outcome for outcome in preferred if counters.get(outcome)]
+    ordered.extend(sorted(outcome for outcome in counters if outcome not in preferred))
+    return ordered
+
+
+def _task_description(event: ProgressEvent) -> str:
+    if event.provider == "hydrate" and event.operation == "context":
+        return "hydrate contexts"
+    label = _operation_label(event.provider, event.operation)
+    return f"{event.context} {label}" if event.context else label
+
+
+def _operation_label(provider: str, operation: str) -> str:
+    if provider == "hydrate" and operation == "component":
+        return "components"
+    if provider == "hydrate" and operation == "file":
+        return "files"
+    return f"{provider} {operation.replace('-', ' ')}"
+
+
+def _target_total_from_detail(detail: str | None) -> int | None:
+    if not detail:
+        return None
+    marker = "targets="
+    if marker not in detail:
+        return None
+    raw = detail.split(marker, 1)[1].split(None, 1)[0]
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return max(value, 0)
+
+
+def _format_units(state: _LiveTaskState) -> str:
+    if state.total is not None:
+        return f"{state.completed}/{state.total}"
+    return f"events {state.completed}"
+
+
+def _format_task_stats(state: _LiveTaskState) -> str:
+    parts: list[str] = []
+    counts = state.counts or Counter()
+    for outcome in ("cache_hit", "cache_miss", "processed", "failed", "done"):
+        total = counts.get(outcome, 0)
+        if total:
+            parts.append(f"{_outcome_label(outcome)}={total}")
+    if state.item_count:
+        parts.append(f"items={state.item_count}")
+    if state.byte_count:
+        parts.append(f"bytes={_format_bytes(state.byte_count)}")
+    if state.latest:
+        parts.append(f"latest={state.latest}")
+    return " ".join(parts)
+
+
+def _format_event_target(event: ProgressEvent) -> str:
+    value = event.target or event.detail or ""
+    return _truncate(value, 56) if value else ""
+
+
+def _format_bytes(value: int) -> str:
+    units = ("B", "KiB", "MiB", "GiB")
+    amount = float(value)
+    for unit in units:
+        if amount < 1024 or unit == units[-1]:
+            if unit == "B":
+                return f"{int(amount)}{unit}"
+            return f"{amount:.1f}{unit}"
+        amount /= 1024
+
+
+def _outcome_label(outcome: str) -> str:
+    return {
+        "cache_hit": "hit",
+        "cache_miss": "miss",
+        "failed": "fail",
+    }.get(outcome, outcome)
+
+
+def _truncate(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    if limit <= 3:
+        return "." * limit
+    return value[: limit - 3] + "..."
+
+
+def _normalize(value: str, fallback: str) -> str:
+    cleaned = str(value or "").strip().replace(" ", "-")
+    return cleaned or fallback
+
+
+def _clean_optional(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None

--- a/src/contextualize/references/audio_transcription.py
+++ b/src/contextualize/references/audio_transcription.py
@@ -32,6 +32,7 @@ from contextualize.plugins.api import (
     TranscriptionRequest,
     TranscriptionResult,
 )
+from contextualize.progress import record_progress
 
 _AUDIO_SUFFIX_TO_MIME: dict[str, str] = {
     ".wav": "audio/wav",
@@ -177,12 +178,18 @@ def transcribe_media_bytes_result(
 ) -> TranscriptionResult:
     kind = _infer_media_kind(filename=filename, content_type=content_type)
     if kind == "audio":
+        suffix = Path(filename).suffix.lower() or ".audio"
         return _transcribe_audio_bytes(
             data,
             filename=filename,
             content_type=content_type or _guess_audio_content_type(filename),
             timeout=timeout,
             plugin_overrides=plugin_overrides,
+            use_cache=True,
+            refresh_cache=refresh_cache,
+            cache_source_sha256=_sha256_bytes(data),
+            cache_source_suffix=suffix,
+            cache_operation="audio-transcription",
         )
     if kind == "video":
         suffix = Path(filename).suffix.lower()
@@ -286,6 +293,7 @@ def _transcribe_video_file_result(
         cached_result = get_cached_local_media_transcript_result(cache_identity)
         if cached_result is not None:
             _log(f"video transcript cache hit for {media_path.name}")
+            record_progress("audio-transcription", "video-transcript", "cache_hit")
             return _result_from_cached_payload(
                 cached_result,
                 fallback_model="cached",
@@ -294,12 +302,14 @@ def _transcribe_video_file_result(
         cached = get_cached_local_media_transcript(cache_identity)
         if cached is not None:
             _log(f"video transcript cache hit for {media_path.name}")
+            record_progress("audio-transcription", "video-transcript", "cache_hit")
             return TranscriptionResult(
                 text=cached,
                 model="cached",
                 provider="cache",
             )
         _log(f"video transcript cache miss for {media_path.name}")
+        record_progress("audio-transcription", "video-transcript", "cache_miss")
 
     from contextualize.runtime import get_cache_only
 
@@ -322,6 +332,7 @@ def _transcribe_video_file_result(
             source_suffix=suffix,
         )
         _log(f"stored video transcript cache for {media_path.name}")
+        record_progress("audio-transcription", "video-transcript", "processed")
     return result
 
 
@@ -452,43 +463,37 @@ def _transcribe_audio_bytes(
                 },
             )
             if use_cache and not should_refresh:
-                cached_result = get_cached_local_media_transcript_result(cache_identity)
+                cached_result = _read_cached_transcription_result(
+                    cache_identity,
+                    provider=provider,
+                    request=request,
+                    filename=filename,
+                )
                 if cached_result is not None:
-                    _log(f"transcript cache hit for {filename} via {provider.name}")
-                    result = _result_from_cached_payload(
-                        cached_result,
-                        fallback_model=provider.name,
-                        fallback_provider=provider.name,
-                    )
-                    _record_transcription_result_metadata(
-                        request, result, filename=filename, source="transcript-cache"
-                    )
-                    return result
-                cached = get_cached_local_media_transcript(cache_identity)
-                if cached is not None:
-                    _log(f"transcript cache hit for {filename} via {provider.name}")
-                    _record_transcription_routing_metadata(
-                        request,
-                        provider=provider.name,
-                        model=_effective_provider_model(provider, request)
-                        or provider.name,
-                        filename=filename,
-                        source="transcript-cache",
-                    )
-                    return TranscriptionResult(
-                        text=cached,
-                        model=provider.name,
-                        provider=provider.name,
-                    )
+                    return cached_result
                 _log(f"transcript cache miss for {filename} via {provider.name}")
+                record_progress(provider.name, "transcript-cache", "cache_miss")
         if cache_only:
             continue
         try:
             _log(f"transcription request start for {filename} via {provider.name}")
+            record_progress(
+                provider.name,
+                "transcription",
+                "start",
+                target=filename,
+            )
             result = provider.transcribe(request)
             _log(
                 "transcription request finished "
                 f"for {filename} via {provider.name} model={result.model}"
+            )
+            record_progress(
+                provider.name,
+                "transcription",
+                "processed",
+                target=filename,
+                detail=f"model={result.model}",
             )
         except (
             TranscriptionProviderUnavailableError,
@@ -500,6 +505,16 @@ def _transcribe_audio_bytes(
             errors.append(str(exc))
             continue
         except TranscriptionProviderError as exc:
+            if cache_identity and use_cache and should_refresh:
+                cached_result = _read_stale_transcription_result_after_error(
+                    cache_identity,
+                    provider=provider,
+                    request=request,
+                    filename=filename,
+                    error=exc,
+                )
+                if cached_result is not None:
+                    return cached_result
             raise RuntimeError(str(exc)) from exc
 
         if cache_identity and use_cache and result.text.strip():
@@ -511,6 +526,7 @@ def _transcribe_audio_bytes(
                 source_suffix=cache_source_suffix,
             )
             _log(f"stored transcript cache for {filename} via {provider.name}")
+            record_progress(provider.name, "transcript-cache", "processed")
         _record_transcription_result_metadata(
             request, result, filename=filename, source="request"
         )
@@ -869,6 +885,93 @@ def _record_transcription_routing_metadata(
         language=request.language,
         filename=filename,
         source=source,
+    )
+
+
+def _read_cached_transcription_result(
+    cache_identity: str,
+    *,
+    provider: TranscriptionProvider,
+    request: TranscriptionRequest,
+    filename: str,
+) -> TranscriptionResult | None:
+    cached_result = get_cached_local_media_transcript_result(cache_identity)
+    if cached_result is not None:
+        _log(f"transcript cache hit for {filename} via {provider.name}")
+        record_progress(provider.name, "transcript-cache", "cache_hit")
+        result = _result_from_cached_payload(
+            cached_result,
+            fallback_model=provider.name,
+            fallback_provider=provider.name,
+        )
+        _record_transcription_result_metadata(
+            request, result, filename=filename, source="transcript-cache"
+        )
+        return result
+
+    cached = get_cached_local_media_transcript(cache_identity)
+    if cached is None:
+        return None
+
+    _log(f"transcript cache hit for {filename} via {provider.name}")
+    record_progress(provider.name, "transcript-cache", "cache_hit")
+    _record_transcription_routing_metadata(
+        request,
+        provider=provider.name,
+        model=_effective_provider_model(provider, request) or provider.name,
+        filename=filename,
+        source="transcript-cache",
+    )
+    return TranscriptionResult(
+        text=cached,
+        model=provider.name,
+        provider=provider.name,
+    )
+
+
+def _read_stale_transcription_result_after_error(
+    cache_identity: str,
+    *,
+    provider: TranscriptionProvider,
+    request: TranscriptionRequest,
+    filename: str,
+    error: TranscriptionProviderError,
+) -> TranscriptionResult | None:
+    if not _is_transient_transcription_error(error):
+        return None
+    cached_result = _read_cached_transcription_result(
+        cache_identity,
+        provider=provider,
+        request=request,
+        filename=filename,
+    )
+    if cached_result is None:
+        return None
+    _log(
+        "using stale transcript cache after refresh error "
+        f"for {filename} via {provider.name}: {error}"
+    )
+    return cached_result
+
+
+def _is_transient_transcription_error(error: TranscriptionProviderError) -> bool:
+    msg = str(error).lower()
+    return any(
+        token in msg
+        for token in (
+            "429",
+            "rate limit",
+            "queue is full",
+            "temporarily",
+            "timeout",
+            "timed out",
+            "connection",
+            "internal server",
+            "500",
+            "502",
+            "503",
+            "504",
+        )
     )
 
 

--- a/src/contextualize/references/factory.py
+++ b/src/contextualize/references/factory.py
@@ -6,16 +6,20 @@ import os
 import re
 import sys
 import tempfile
+from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
+from ..concurrency import media_task_semaphore, run_indexed_tasks_fail_fast
 from ..plugins.resolve import (
     list_plugin_targets,
     materialize_plugin_target,
     resolve_plugin_references,
 )
+from ..plugins.reference import PluginReference
+from ..progress import log_progress, record_progress
+from ..runtime import get_payload_media_jobs
 from ..git.target import parse_git_target
 from ..utils import brace_expand, count_tokens
 from .file import FileExistenceReference, FileReference
@@ -25,6 +29,7 @@ from .helpers import (
     fetch_gist_files,
     is_http_url,
     is_utf8_file,
+    looks_like_text_content_type,
     looks_like_windows_drive,
     parse_gist_url,
     parse_target_spec,
@@ -33,21 +38,122 @@ from .helpers import (
 from .url import URLReference
 
 _EXTERNAL_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+_CONVERTIBLE_CONTENT_TYPES = frozenset(
+    {
+        "application/pdf",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    }
+)
 
 
-def _target_suffix(target: str) -> str:
-    if is_http_url(target):
-        return Path(urlparse(target).path).suffix.lower()
-    return Path(target).suffix.lower()
+@dataclass(frozen=True)
+class _EmbeddedResolutionTarget:
+    target: str
+    context_prefix: str | None = None
+    context_sidecar_stem: str | None = None
 
 
-def _allows_embedded_direct_resolution(target: str, *, plugin_matched: bool) -> bool:
-    if plugin_matched:
-        return True
-    if is_http_url(target):
-        suffix = _target_suffix(target)
-        return suffix in MARKITDOWN_PREFERRED_EXTENSIONS or is_media_suffix(suffix)
-    return not _EXTERNAL_SCHEME_RE.match(target)
+_EmbeddedResolutionSeenKey = tuple[str, str | None, str | None]
+
+
+def _text_only_materialized_mode(file_item: dict[str, Any]) -> str:
+    content_type = str(file_item.get("content_type") or "").split(";", 1)[0].lower()
+    filename = str(file_item.get("filename") or "")
+    suffix = Path(filename).suffix.lower()
+    if content_type and looks_like_text_content_type(content_type):
+        return "text"
+    if (
+        content_type.startswith(("audio/", "image/", "video/"))
+        or content_type in _CONVERTIBLE_CONTENT_TYPES
+        or suffix in MARKITDOWN_PREFERRED_EXTENSIONS
+        or is_media_suffix(suffix)
+    ):
+        return "convertible"
+    if content_type:
+        return "skip"
+    return "text"
+
+
+def _normalize_context_prefix(value: object) -> str | None:
+    if value is None:
+        return None
+    raw = str(value).strip().strip("/")
+    if not raw:
+        return None
+    parts = [part for part in raw.split("/") if part and part not in {".", ".."}]
+    return "/".join(parts) or None
+
+
+def _join_context_prefix(prefix: object, suffix: object) -> str | None:
+    clean_prefix = _normalize_context_prefix(prefix)
+    clean_suffix = _normalize_context_prefix(suffix)
+    if clean_prefix and clean_suffix:
+        return f"{clean_prefix}/{clean_suffix}"
+    return clean_prefix or clean_suffix
+
+
+def _embedded_child_context(
+    item: dict[str, Any], parent: _EmbeddedResolutionTarget
+) -> tuple[str | None, str | None]:
+    metadata = item.get("metadata")
+    if not isinstance(metadata, dict):
+        return parent.context_prefix, parent.context_sidecar_stem
+    channel_path = metadata.get("channel_path")
+    block_id = metadata.get("block_id")
+    if channel_path is not None and block_id is not None:
+        return (
+            _normalize_context_prefix(channel_path),
+            _join_context_prefix(channel_path, block_id),
+        )
+    context_prefix = metadata.get("context_prefix")
+    if context_prefix is not None:
+        return (
+            _join_context_prefix(parent.context_prefix, context_prefix),
+            parent.context_sidecar_stem,
+        )
+    return parent.context_prefix, parent.context_sidecar_stem
+
+
+def _apply_embedded_context(
+    refs: list[Any],
+    *,
+    context_prefix: str | None,
+    context_sidecar_stem: str | None,
+) -> list[Any]:
+    clean_prefix = _normalize_context_prefix(context_prefix)
+    clean_sidecar_stem = _normalize_context_prefix(context_sidecar_stem)
+    if clean_prefix is None and clean_sidecar_stem is None:
+        return refs
+    for ref in refs:
+        if isinstance(ref, PluginReference):
+            if clean_prefix is not None:
+                ref.document.metadata["context_prefix"] = clean_prefix
+            if clean_sidecar_stem is not None:
+                ref.document.metadata["context_sidecar_stem"] = clean_sidecar_stem
+        else:
+            if clean_prefix is not None:
+                setattr(ref, "_contextualize_context_prefix", clean_prefix)
+            if clean_sidecar_stem is not None:
+                setattr(
+                    ref,
+                    "_contextualize_context_sidecar_stem",
+                    clean_sidecar_stem,
+                )
+    return refs
+
+
+def _embedded_seen_key(
+    target: str,
+    context_prefix: str | None,
+    context_sidecar_stem: str | None,
+) -> _EmbeddedResolutionSeenKey:
+    return (
+        target,
+        _normalize_context_prefix(context_prefix),
+        _normalize_context_prefix(context_sidecar_stem),
+    )
 
 
 def create_file_references(
@@ -70,20 +176,15 @@ def create_file_references(
     discord_overrides: dict | None = None,
     atproto_overrides: dict | None = None,
     soundcloud_overrides: dict[str, Any] | None = None,
-    target_depth: int = 0,
-    target_scope: str = "all",
-    include_parent: bool = True,
+    embedded_resolution: bool = False,
     binary_policy: str = "error",
-    _embedded_seen: set[str] | None = None,
+    _embedded_resolution_seen: set[_EmbeddedResolutionSeenKey] | None = None,
 ):
     """
     Build a list of file references from the specified paths.
 
     If `inject` is true, {cx::...} markers are resolved before wrapping.
     """
-    target_scope = (target_scope or "all").lower()
-    if target_scope not in {"first", "all"}:
-        raise ValueError("target_scope must be 'first' or 'all'")
     if binary_policy not in {"error", "placeholder", "skip"}:
         raise ValueError("binary_policy must be 'error', 'placeholder', or 'skip'")
 
@@ -183,46 +284,6 @@ def create_file_references(
     ):
         if provider_overrides is not None:
             effective_plugin_overrides.setdefault(provider_name, provider_overrides)
-
-    embedded_seed_targets = [
-        str(parse_target_spec(raw_path).get("target", raw_path))
-        for raw_path in expanded_all_paths
-    ]
-    if target_depth > 0 and not include_parent:
-        seed_targets = embedded_seed_targets
-        if target_scope == "first":
-            seed_targets = seed_targets[:1]
-        file_references = _resolve_embedded_target_refs(
-            seed_targets,
-            ignore_patterns=ignore_patterns,
-            format=format,
-            label=label,
-            label_suffix=label_suffix,
-            include_token_count=include_token_count,
-            token_target=token_target,
-            inject=inject,
-            depth=depth,
-            trace_collector=trace_collector,
-            text_only=text_only,
-            use_cache=use_cache,
-            cache_ttl=cache_ttl,
-            refresh_cache=refresh_cache,
-            plugin_overrides=effective_plugin_overrides,
-            arena_overrides=arena_overrides,
-            discord_overrides=discord_overrides,
-            atproto_overrides=atproto_overrides,
-            soundcloud_overrides=soundcloud_overrides,
-            target_depth=target_depth,
-            target_scope=target_scope,
-            binary_policy=binary_policy,
-            seen=_embedded_seen,
-        )
-        return {
-            "refs": file_references,
-            "concatenated": concat_refs(file_references),
-            "ignored_files": ignored_files,
-            "ignored_folders": {},
-        }
 
     for raw_path in expanded_all_paths:
         spec_opts = parse_target_spec(raw_path)
@@ -446,12 +507,9 @@ def create_file_references(
         r for r in file_references if not getattr(r, "cache_miss", False)
     ]
 
-    if target_depth > 0:
-        seed_targets = embedded_seed_targets
-        if target_scope == "first":
-            seed_targets = seed_targets[:1]
-        embedded_refs = _resolve_embedded_target_refs(
-            seed_targets,
+    if embedded_resolution:
+        embedded_refs = _resolve_embedded_resolution_refs(
+            file_references,
             ignore_patterns=ignore_patterns,
             format=format,
             label=label,
@@ -470,14 +528,10 @@ def create_file_references(
             discord_overrides=discord_overrides,
             atproto_overrides=atproto_overrides,
             soundcloud_overrides=soundcloud_overrides,
-            target_depth=target_depth,
-            target_scope=target_scope,
             binary_policy=binary_policy,
-            seen=_embedded_seen,
+            seen=_embedded_resolution_seen,
         )
-        file_references = (
-            [*file_references, *embedded_refs] if include_parent else embedded_refs
-        )
+        file_references = [*file_references, *embedded_refs]
 
     return {
         "refs": file_references,
@@ -492,8 +546,55 @@ def concat_refs(file_references):
     return "\n\n".join(ref.output for ref in file_references)
 
 
-def _resolve_embedded_target_refs(
-    seed_targets: list[str],
+def _embedded_target_from_ref(ref: Any) -> _EmbeddedResolutionTarget | None:
+    if not isinstance(ref, PluginReference):
+        return None
+    metadata = ref.document.metadata or {}
+    provider = metadata.get("provider") or metadata.get("plugin_name")
+    context_subpath = metadata.get("context_subpath")
+
+    def sidecar_from_context() -> str | None:
+        if not isinstance(context_subpath, str) or not context_subpath.strip():
+            return None
+        stem = context_subpath.strip().lstrip("/")
+        if stem.endswith(".md"):
+            stem = stem[:-3]
+        return stem
+
+    if provider != "arena":
+        target = ref.source or ref.path
+        if not isinstance(target, str) or not target.strip():
+            return None
+        return _EmbeddedResolutionTarget(
+            target.strip(),
+            context_sidecar_stem=sidecar_from_context(),
+        )
+    block_type = metadata.get("block_type")
+    if block_type == "Channel":
+        return None
+    block_id = metadata.get("block_id")
+    if not isinstance(block_id, (int, str)) or not str(block_id).strip():
+        return None
+    target = f"https://www.are.na/block/{str(block_id).strip()}"
+
+    channel_path = metadata.get("channel_path")
+    if isinstance(channel_path, str) and channel_path.strip():
+        clean_channel = _normalize_context_prefix(channel_path)
+        return _EmbeddedResolutionTarget(
+            target,
+            context_prefix=clean_channel,
+            context_sidecar_stem=_join_context_prefix(clean_channel, block_id),
+        )
+
+    stem = sidecar_from_context()
+    if stem is not None:
+        return _EmbeddedResolutionTarget(target, context_sidecar_stem=stem)
+
+    return _EmbeddedResolutionTarget(target)
+
+
+def _resolve_embedded_resolution_refs(
+    parent_refs: list[Any],
     *,
     ignore_patterns,
     format: str,
@@ -513,78 +614,192 @@ def _resolve_embedded_target_refs(
     discord_overrides: dict | None,
     atproto_overrides: dict | None,
     soundcloud_overrides: dict[str, Any] | None,
-    target_depth: int,
-    target_scope: str,
     binary_policy: str,
-    seen: set[str] | None,
+    seen: set[_EmbeddedResolutionSeenKey] | None,
 ) -> list[Any]:
-    if target_depth <= 0:
+    embedded_targets = [
+        target for ref in parent_refs if (target := _embedded_target_from_ref(ref))
+    ]
+    if not embedded_targets:
         return []
     if seen is None:
-        seen = set(seed_targets)
+        seen = set()
 
     refs: list[Any] = []
-    frontier = list(seed_targets)
-    for _ in range(target_depth):
-        next_frontier: list[str] = []
-        for target in frontier:
-            try:
-                listed = list_plugin_targets(
-                    target,
-                    overrides=plugin_overrides,
+    media_jobs = get_payload_media_jobs()
+    log_progress(
+        "plugins",
+        "embedded-list",
+        "start",
+        detail=f"targets={len(embedded_targets)} jobs={media_jobs}",
+    )
+    list_tasks = [
+        (
+            index,
+            (
+                lambda current=node.target: _list_embedded_targets_safely(
+                    current,
+                    plugin_overrides=plugin_overrides,
                     use_cache=use_cache,
                     cache_ttl=cache_ttl,
                     refresh_cache=refresh_cache,
                 )
-            except Exception as exc:
-                print(
-                    f"Warning: embedded target listing failed for {target}: {exc}",
-                    file=sys.stderr,
-                )
+            ),
+        )
+        for index, node in enumerate(embedded_targets)
+    ]
+    listed_results = run_indexed_tasks_fail_fast(
+        list_tasks,
+        max_workers=media_jobs,
+        semaphore=media_task_semaphore(),
+        on_complete=_record_embedded_list_completion,
+    )
+    child_jobs: list[tuple[int, _EmbeddedResolutionTarget]] = []
+    encounter_index = 0
+    for list_index, (target, listed, error) in listed_results:
+        parent = embedded_targets[list_index]
+        if error is not None:
+            print(
+                f"Warning: embedded resolution target listing failed for {target}: {error}",
+                file=sys.stderr,
+            )
+            record_progress(
+                "plugins",
+                "embedded-list",
+                "failed",
+                target=target,
+                detail=str(error),
+            )
+            continue
+        provider_name = getattr(listed, "plugin_name", None) or "plugins"
+        item_count = len(getattr(listed, "items", ()) or ())
+        record_progress(
+            str(provider_name),
+            "list-targets",
+            "processed",
+            target=target,
+            count=item_count,
+        )
+        for item in listed.items:
+            child = item.get("target")
+            if not isinstance(child, str) or not child:
                 continue
-            for item in listed.items:
-                child = item.get("target")
-                if not isinstance(child, str) or not child or child in seen:
-                    continue
-                if item.get("traverse") is False:
-                    continue
-                seen.add(child)
-                next_frontier.append(child)
-                refs.extend(
-                    _resolve_embedded_child_refs(
-                        child,
-                        ignore_patterns=ignore_patterns,
-                        format=format,
-                        label=label,
-                        label_suffix=label_suffix,
-                        include_token_count=include_token_count,
-                        token_target=token_target,
-                        inject=inject,
-                        depth=depth,
-                        trace_collector=trace_collector,
-                        text_only=text_only,
-                        use_cache=use_cache,
-                        cache_ttl=cache_ttl,
-                        refresh_cache=refresh_cache,
-                        plugin_overrides=plugin_overrides,
-                        arena_overrides=arena_overrides,
-                        discord_overrides=discord_overrides,
-                        atproto_overrides=atproto_overrides,
-                        soundcloud_overrides=soundcloud_overrides,
-                        binary_policy=binary_policy,
-                        seen=seen,
-                    )
+            if item.get("traverse") is False:
+                continue
+            child_prefix, child_sidecar_stem = _embedded_child_context(item, parent)
+            seen_key = _embedded_seen_key(child, child_prefix, child_sidecar_stem)
+            if seen_key in seen:
+                continue
+            seen.add(seen_key)
+            child_node = _EmbeddedResolutionTarget(
+                child,
+                context_prefix=child_prefix,
+                context_sidecar_stem=child_sidecar_stem,
+            )
+            child_jobs.append((encounter_index, child_node))
+            encounter_index += 1
+
+    log_progress(
+        "plugins",
+        "embedded-list",
+        "done",
+        detail="targets",
+        count=len(child_jobs),
+    )
+    if not child_jobs:
+        log_progress("plugins", "embedded-resolve", "done", detail="targets", count=0)
+        return refs
+
+    log_progress(
+        "plugins",
+        "embedded-resolve",
+        "start",
+        detail=f"targets={len(child_jobs)} jobs={media_jobs}",
+    )
+    resolve_tasks = [
+        (
+            index,
+            (
+                lambda current=child: _resolve_embedded_child_refs(
+                    current,
+                    ignore_patterns=ignore_patterns,
+                    format=format,
+                    label=label,
+                    label_suffix=label_suffix,
+                    include_token_count=include_token_count,
+                    token_target=token_target,
+                    inject=inject,
+                    depth=depth,
+                    trace_collector=trace_collector,
+                    text_only=text_only,
+                    use_cache=use_cache,
+                    cache_ttl=cache_ttl,
+                    refresh_cache=refresh_cache,
+                    plugin_overrides=plugin_overrides,
+                    arena_overrides=arena_overrides,
+                    discord_overrides=discord_overrides,
+                    atproto_overrides=atproto_overrides,
+                    soundcloud_overrides=soundcloud_overrides,
+                    binary_policy=binary_policy,
+                    seen=seen,
                 )
-        if target_scope == "first" and next_frontier:
-            next_frontier = next_frontier[:1]
-        frontier = next_frontier
-        if not frontier:
-            break
+            ),
+        )
+        for index, child in child_jobs
+    ]
+    child_targets = {index: child.target for index, child in child_jobs}
+
+    def _record_child_resolved(index, child_refs):
+        record_progress(
+            "plugins",
+            "embedded-resolve",
+            "processed",
+            target=child_targets.get(index),
+            count=len(child_refs),
+        )
+
+    resolved_total = 0
+    for _, child_refs in run_indexed_tasks_fail_fast(
+        resolve_tasks,
+        max_workers=media_jobs,
+        semaphore=media_task_semaphore(),
+        on_complete=_record_child_resolved,
+    ):
+        resolved_total += len(child_refs)
+        refs.extend(child_refs)
+    log_progress("plugins", "embedded-resolve", "done", detail="targets", count=resolved_total)
     return refs
 
 
-def _resolve_embedded_child_refs(
+def _record_embedded_list_completion(_index: int, result: Any) -> None:
+    target, _listed, error = result
+    if error is None:
+        record_progress("plugins", "embedded-list", "processed", target=target)
+
+
+def _list_embedded_targets_safely(
     target: str,
+    *,
+    plugin_overrides: dict[str, Any],
+    use_cache: bool,
+    cache_ttl: timedelta | None,
+    refresh_cache: bool,
+) -> tuple[str, Any | None, Exception | None]:
+    try:
+        listed = list_plugin_targets(
+            target,
+            overrides=plugin_overrides,
+            use_cache=use_cache,
+            cache_ttl=cache_ttl,
+            refresh_cache=refresh_cache,
+        )
+    except Exception as exc:
+        return target, None, exc
+    return target, listed, None
+
+
+def _resolve_embedded_child_refs(
+    target_node: _EmbeddedResolutionTarget,
     *,
     ignore_patterns,
     format: str,
@@ -605,8 +820,9 @@ def _resolve_embedded_child_refs(
     atproto_overrides: dict | None,
     soundcloud_overrides: dict[str, Any] | None,
     binary_policy: str,
-    seen: set[str],
+    seen: set[_EmbeddedResolutionSeenKey],
 ) -> list[Any]:
+    target = target_node.target
     try:
         plugin_refs, plugin_claimed = resolve_plugin_references(
             target,
@@ -625,13 +841,17 @@ def _resolve_embedded_child_refs(
         )
     except Exception as exc:
         print(
-            f"Warning: embedded plugin target resolution failed for {target}: {exc}",
+            f"Warning: embedded resolution plugin target failed for {target}: {exc}",
             file=sys.stderr,
         )
         plugin_refs = []
         plugin_claimed = False
     if plugin_refs:
-        return plugin_refs
+        return _apply_embedded_context(
+            plugin_refs,
+            context_prefix=target_node.context_prefix,
+            context_sidecar_stem=target_node.context_sidecar_stem,
+        )
 
     try:
         materialized = materialize_plugin_target(
@@ -643,19 +863,20 @@ def _resolve_embedded_child_refs(
         )
     except Exception as exc:
         print(
-            f"Warning: embedded target materialization failed for {target}: {exc}",
+            f"Warning: embedded resolution materialization failed for {target}: {exc}",
             file=sys.stderr,
         )
         materialized = None
-
-    plugin_matched = plugin_claimed or bool(
-        materialized is not None and materialized.matched
-    )
 
     if materialized is not None and materialized.files:
         refs: list[Any] = []
         with tempfile.TemporaryDirectory(prefix="contextualize-target-") as tmpdir:
             for file_item in materialized.files:
+                materialized_mode = (
+                    _text_only_materialized_mode(file_item) if text_only else "text"
+                )
+                if materialized_mode == "skip":
+                    continue
                 path = Path(tmpdir) / _safe_materialized_filename(
                     str(file_item.get("filename") or "attachment")
                 )
@@ -672,7 +893,7 @@ def _resolve_embedded_child_refs(
                         inject=inject,
                         depth=depth,
                         trace_collector=trace_collector,
-                        text_only=text_only,
+                        text_only=text_only and materialized_mode != "convertible",
                         use_cache=use_cache,
                         cache_ttl=cache_ttl,
                         refresh_cache=refresh_cache,
@@ -681,53 +902,25 @@ def _resolve_embedded_child_refs(
                         discord_overrides=discord_overrides,
                         atproto_overrides=atproto_overrides,
                         soundcloud_overrides=soundcloud_overrides,
-                        target_depth=0,
-                        binary_policy=binary_policy,
-                        _embedded_seen=seen,
+                        embedded_resolution=False,
+                        binary_policy="skip" if text_only else binary_policy,
+                        _embedded_resolution_seen=seen,
                     )
-                    refs.extend(result["refs"])
+                    refs.extend(
+                        _apply_embedded_context(
+                            list(result["refs"]),
+                            context_prefix=target_node.context_prefix,
+                            context_sidecar_stem=target_node.context_sidecar_stem,
+                        )
+                    )
                 except Exception as exc:
                     print(
-                        f"Warning: embedded materialized target failed for {target}: {exc}",
+                        f"Warning: embedded resolution materialized target failed for {target}: {exc}",
                         file=sys.stderr,
                     )
         return refs
 
-    if not _allows_embedded_direct_resolution(target, plugin_matched=plugin_matched):
-        return []
-
-    try:
-        result = create_file_references(
-            [target],
-            ignore_patterns=ignore_patterns,
-            format=format,
-            label=label,
-            label_suffix=label_suffix,
-            include_token_count=include_token_count,
-            token_target=token_target,
-            inject=inject,
-            depth=depth,
-            trace_collector=trace_collector,
-            text_only=text_only,
-            use_cache=use_cache,
-            cache_ttl=cache_ttl,
-            refresh_cache=refresh_cache,
-            plugin_overrides=plugin_overrides,
-            arena_overrides=arena_overrides,
-            discord_overrides=discord_overrides,
-            atproto_overrides=atproto_overrides,
-            soundcloud_overrides=soundcloud_overrides,
-            target_depth=0,
-            binary_policy=binary_policy,
-            _embedded_seen=seen,
-        )
-    except Exception as exc:
-        print(
-            f"Warning: embedded target resolution failed for {target}: {exc}",
-            file=sys.stderr,
-        )
-        return []
-    return list(result["refs"])
+    return []
 
 
 def _safe_materialized_filename(filename: str) -> str:

--- a/src/contextualize/references/helpers.py
+++ b/src/contextualize/references/helpers.py
@@ -179,9 +179,9 @@ def _looks_like_bare_external_target(spec: str) -> bool:
 
 def split_spec_symbols(spec: str) -> tuple[str, list[str]]:
     try:
-        from ..plugins.resolve import classify_plugin_target
+        from ..plugins.resolve import plugin_target_provider
 
-        if classify_plugin_target(spec) is not None:
+        if plugin_target_provider(spec) is not None:
             return spec, []
     except Exception:
         pass

--- a/src/contextualize/references/url.py
+++ b/src/contextualize/references/url.py
@@ -752,6 +752,7 @@ class URLReference:
                 media_kwargs = {
                     "filename": media_name,
                     "content_type": content_type or None,
+                    "refresh_cache": self.refresh_cache,
                 }
                 if self.plugin_overrides is not None:
                     media_kwargs["plugin_overrides"] = self.plugin_overrides

--- a/src/contextualize/references/video_context.py
+++ b/src/contextualize/references/video_context.py
@@ -12,6 +12,7 @@ import subprocess
 import tempfile
 from typing import Any
 
+from contextualize.concurrency import media_task_semaphore, run_indexed_tasks_fail_fast
 from contextualize.cache.local_media import (
     get_cached_transcript as get_cached_local_media_text,
 )
@@ -19,6 +20,8 @@ from contextualize.cache.local_media import (
     store_transcript as store_local_media_text,
 )
 from contextualize.plugins.api import TranscriptionResult
+from contextualize.progress import record_progress
+from contextualize.runtime import get_payload_media_jobs
 
 from .audio_transcription import CacheMissError
 from .audio_transcription import _video_suffix_from_content_type
@@ -165,7 +168,9 @@ def render_video_frame_section(
     if use_cache and not _should_refresh_video(refresh_cache):
         cached = get_cached_local_media_text(cache_identity)
         if cached:
+            record_progress("video", "frame-section", "cache_hit")
             return cached
+    record_progress("video", "frame-section", "cache_miss", count=len(timestamps))
 
     from contextualize.runtime import get_cache_only
 
@@ -174,32 +179,30 @@ def render_video_frame_section(
 
     frames = []
     with tempfile.TemporaryDirectory() as tmpdir:
-        for index, timestamp in enumerate(timestamps, start=1):
-            image_path = extract_video_frame(
-                video_path,
-                timestamp_seconds=timestamp,
-                output_dir=Path(tmpdir),
-                index=index,
-            )
-            speech = speech_anchor_for_timestamp(timestamp, segments)
-            if speech_units:
-                speech = speech_anchor_for_timestamp(timestamp, speech_units)
-            description = None
-            if settings.frame_descriptions and image_path is not None:
-                description = describe_video_frame(
-                    image_path,
-                    timestamp_seconds=timestamp,
-                    speech=speech,
-                    source_url=source_url,
-                )
-            frames.append(
-                VideoFrame(
-                    index=index,
-                    timestamp=timestamp,
-                    speech=speech,
-                    description=description,
+        frame_tasks = [
+            (
+                index,
+                (
+                    lambda idx=index, ts=timestamp: _build_video_frame(
+                        video_path,
+                        timestamp=ts,
+                        index=idx,
+                        output_dir=Path(tmpdir),
+                        segments=segments,
+                        speech_units=speech_units,
+                        settings=settings,
+                        source_url=source_url,
+                    )
                 )
             )
+            for index, timestamp in enumerate(timestamps, start=1)
+        ]
+        for _, frame in run_indexed_tasks_fail_fast(
+            frame_tasks,
+            max_workers=get_payload_media_jobs(),
+            semaphore=media_task_semaphore(),
+        ):
+            frames.append(frame)
     section = format_video_frame_section(frames)
     if use_cache and section.strip():
         store_local_media_text(
@@ -209,7 +212,44 @@ def render_video_frame_section(
             source_sha256=source_sha256,
             source_suffix=source_suffix,
         )
+        record_progress("video", "frame-section", "processed", count=len(frames))
     return section
+
+
+def _build_video_frame(
+    video_path: Path,
+    *,
+    timestamp: float,
+    index: int,
+    output_dir: Path,
+    segments: list[VideoSegment],
+    speech_units: list[VideoSegment],
+    settings: VideoFrameSettings,
+    source_url: str | None,
+) -> VideoFrame:
+    image_path = extract_video_frame(
+        video_path,
+        timestamp_seconds=timestamp,
+        output_dir=output_dir,
+        index=index,
+    )
+    speech = speech_anchor_for_timestamp(timestamp, segments)
+    if speech_units:
+        speech = speech_anchor_for_timestamp(timestamp, speech_units)
+    description = None
+    if settings.frame_descriptions and image_path is not None:
+        description = describe_video_frame(
+            image_path,
+            timestamp_seconds=timestamp,
+            speech=speech,
+            source_url=source_url,
+        )
+    return VideoFrame(
+        index=index,
+        timestamp=timestamp,
+        speech=speech,
+        description=description,
+    )
 
 
 def resolve_video_frame_settings(

--- a/src/contextualize/render/codex.py
+++ b/src/contextualize/render/codex.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import atexit
 from collections import deque
 from pathlib import Path
 from queue import Empty, Queue
@@ -247,6 +248,121 @@ class _CodexAppServerClient:
             return
 
 
+class _SharedCodexAppServerSession:
+    def __init__(self, command: str) -> None:
+        self._command = command
+        self._lock = threading.Lock()
+        self._client: _CodexAppServerClient | None = None
+
+    def close(self) -> None:
+        with self._lock:
+            client = self._client
+            self._client = None
+            if client is not None:
+                client.close()
+
+    def probe(self, *, timeout_seconds: float) -> None:
+        with self._lock:
+            client = self._ensure_client(
+                startup_timeout_seconds=timeout_seconds,
+                request_timeout_seconds=timeout_seconds,
+            )
+            client.request("model/list", params={"includeHidden": False})
+
+    def describe_image(
+        self,
+        image_path: Path,
+        *,
+        prompt: str,
+        model: str | None,
+        effort: str | None,
+        timeout_seconds: float,
+    ) -> CodexImageDescriptionResult:
+        with self._lock:
+            client = self._ensure_client(
+                startup_timeout_seconds=min(10.0, timeout_seconds),
+                request_timeout_seconds=timeout_seconds,
+            )
+            return _describe_image_with_client(
+                client,
+                image_path,
+                prompt=prompt,
+                model=model,
+                effort=effort,
+                timeout_seconds=timeout_seconds,
+            )
+
+    def transcribe_image_batches(
+        self,
+        image_batches: list[list[Path]],
+        *,
+        prompts: list[str],
+        model: str | None,
+        effort: str | None,
+        timeout_seconds: float,
+    ) -> list[CodexImageDescriptionResult]:
+        with self._lock:
+            client = self._ensure_client(
+                startup_timeout_seconds=min(10.0, timeout_seconds),
+                request_timeout_seconds=timeout_seconds,
+            )
+            return _transcribe_image_batches_with_client(
+                client,
+                image_batches,
+                prompts=prompts,
+                model=model,
+                effort=effort,
+                timeout_seconds=timeout_seconds,
+            )
+
+    def _ensure_client(
+        self,
+        *,
+        startup_timeout_seconds: float,
+        request_timeout_seconds: float,
+    ) -> _CodexAppServerClient:
+        if self._client is not None:
+            return self._client
+        client = _CodexAppServerClient(
+            command=self._command,
+            startup_timeout_seconds=startup_timeout_seconds,
+            request_timeout_seconds=request_timeout_seconds,
+        )
+        try:
+            client.start()
+            client.initialize()
+        except Exception:
+            client.close()
+            raise
+        self._client = client
+        return client
+
+
+_SHARED_SESSIONS: dict[str, _SharedCodexAppServerSession] = {}
+_SHARED_SESSIONS_LOCK = threading.Lock()
+
+
+def close_shared_codex_app_server_sessions() -> None:
+    with _SHARED_SESSIONS_LOCK:
+        sessions = list(_SHARED_SESSIONS.values())
+        _SHARED_SESSIONS.clear()
+    for session in sessions:
+        session.close()
+
+
+atexit.register(close_shared_codex_app_server_sessions)
+
+
+def _shared_session(command: str) -> _SharedCodexAppServerSession:
+    key = " ".join(_split_command(command))
+    with _SHARED_SESSIONS_LOCK:
+        session = _SHARED_SESSIONS.get(key)
+        if session is None:
+            session = _SharedCodexAppServerSession(command)
+            _SHARED_SESSIONS[key] = session
+        return session
+
+
 def _split_command(command: str) -> tuple[str, ...]:
     raw = command.strip()
     if not raw:
@@ -314,6 +430,22 @@ def is_codex_app_server_live(
     return True, None
 
 
+def is_shared_codex_app_server_live(
+    command: str,
+    *,
+    timeout_seconds: float = 8.0,
+) -> tuple[bool, str | None]:
+    session: _SharedCodexAppServerSession | None = None
+    try:
+        session = _shared_session(command)
+        session.probe(timeout_seconds=timeout_seconds)
+    except CodexAppServerError as exc:
+        if session is not None:
+            session.close()
+        return False, str(exc)
+    return True, None
+
+
 def describe_image_with_codex_app_server(
     image_path: Path,
     *,
@@ -331,26 +463,38 @@ def describe_image_with_codex_app_server(
         request_timeout_seconds=timeout_seconds,
     ) as client:
         client.initialize()
-        start_params: dict[str, Any] = {"cwd": str(Path.cwd()), "ephemeral": True}
-        thread_id = _thread_id(client.request("thread/start", params=start_params))
-        input_items: list[dict[str, Any]] = [
-            {"type": "text", "text": prompt},
-            {"type": "localImage", "path": str(image_path)},
-        ]
-        turn_params: dict[str, Any] = {"threadId": thread_id, "input": input_items}
-        model_name = (model or "").strip()
-        effort_name = (effort or "").strip()
-        if model_name:
-            turn_params["model"] = model_name
-        if effort_name:
-            turn_params["effort"] = effort_name
-        turn_id = _turn_id(client.request("turn/start", params=turn_params))
-        return _collect_turn_text(
+        return _describe_image_with_client(
             client,
-            turn_id=turn_id,
+            image_path,
+            prompt=prompt,
+            model=model,
+            effort=effort,
             timeout_seconds=timeout_seconds,
-            requested_model=model_name or None,
         )
+
+
+def describe_image_with_shared_codex_app_server(
+    image_path: Path,
+    *,
+    prompt: str,
+    command: str,
+    model: str | None = None,
+    effort: str | None = None,
+    timeout_seconds: float = 30.0,
+) -> CodexImageDescriptionResult:
+    if not image_path.exists():
+        raise CodexAppServerError(f"Image path does not exist: {image_path}")
+    try:
+        return _shared_session(command).describe_image(
+            image_path,
+            prompt=prompt,
+            model=model,
+            effort=effort,
+            timeout_seconds=timeout_seconds,
+        )
+    except CodexAppServerError:
+        _shared_session(command).close()
+        raise
 
 
 def transcribe_image_batches_with_codex_app_server(
@@ -362,52 +506,127 @@ def transcribe_image_batches_with_codex_app_server(
     effort: str | None = None,
     timeout_seconds: float = 30.0,
 ) -> list[CodexImageDescriptionResult]:
-    if len(image_batches) != len(prompts):
-        raise CodexAppServerError("Image batch and prompt counts do not match")
-    if not image_batches:
-        return []
-    for batch in image_batches:
-        if not batch:
-            raise CodexAppServerError("Image batch cannot be empty")
-        for image_path in batch:
-            if not image_path.exists():
-                raise CodexAppServerError(f"Image path does not exist: {image_path}")
-
-    results: list[CodexImageDescriptionResult] = []
+    _validate_image_batches(image_batches, prompts)
     with _CodexAppServerClient(
         command=command,
         startup_timeout_seconds=min(10.0, timeout_seconds),
         request_timeout_seconds=timeout_seconds,
     ) as client:
         client.initialize()
-        start_params: dict[str, Any] = {"cwd": str(Path.cwd()), "ephemeral": True}
-        thread_id = _thread_id(client.request("thread/start", params=start_params))
-        model_name = (model or "").strip()
-        effort_name = (effort or "").strip()
-        for batch, prompt in zip(image_batches, prompts, strict=True):
-            input_items: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
-            input_items.extend(
-                {"type": "localImage", "path": str(image_path)}
-                for image_path in batch
+        return _transcribe_image_batches_with_client(
+            client,
+            image_batches,
+            prompts=prompts,
+            model=model,
+            effort=effort,
+            timeout_seconds=timeout_seconds,
+        )
+
+
+def transcribe_image_batches_with_shared_codex_app_server(
+    image_batches: list[list[Path]],
+    *,
+    prompts: list[str],
+    command: str,
+    model: str | None = None,
+    effort: str | None = None,
+    timeout_seconds: float = 30.0,
+) -> list[CodexImageDescriptionResult]:
+    _validate_image_batches(image_batches, prompts)
+    try:
+        return _shared_session(command).transcribe_image_batches(
+            image_batches,
+            prompts=prompts,
+            model=model,
+            effort=effort,
+            timeout_seconds=timeout_seconds,
+        )
+    except CodexAppServerError:
+        _shared_session(command).close()
+        raise
+
+
+def _describe_image_with_client(
+    client: _CodexAppServerClient,
+    image_path: Path,
+    *,
+    prompt: str,
+    model: str | None,
+    effort: str | None,
+    timeout_seconds: float,
+) -> CodexImageDescriptionResult:
+    start_params: dict[str, Any] = {"cwd": str(Path.cwd()), "ephemeral": True}
+    thread_id = _thread_id(client.request("thread/start", params=start_params))
+    input_items: list[dict[str, Any]] = [
+        {"type": "text", "text": prompt},
+        {"type": "localImage", "path": str(image_path)},
+    ]
+    turn_params: dict[str, Any] = {"threadId": thread_id, "input": input_items}
+    model_name = (model or "").strip()
+    effort_name = (effort or "").strip()
+    if model_name:
+        turn_params["model"] = model_name
+    if effort_name:
+        turn_params["effort"] = effort_name
+    turn_id = _turn_id(client.request("turn/start", params=turn_params))
+    return _collect_turn_text(
+        client,
+        turn_id=turn_id,
+        timeout_seconds=timeout_seconds,
+        requested_model=model_name or None,
+    )
+
+
+def _transcribe_image_batches_with_client(
+    client: _CodexAppServerClient,
+    image_batches: list[list[Path]],
+    *,
+    prompts: list[str],
+    model: str | None,
+    effort: str | None,
+    timeout_seconds: float,
+) -> list[CodexImageDescriptionResult]:
+    if not image_batches:
+        return []
+    results: list[CodexImageDescriptionResult] = []
+    start_params: dict[str, Any] = {"cwd": str(Path.cwd()), "ephemeral": True}
+    thread_id = _thread_id(client.request("thread/start", params=start_params))
+    model_name = (model or "").strip()
+    effort_name = (effort or "").strip()
+    for batch, prompt in zip(image_batches, prompts, strict=True):
+        input_items: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
+        input_items.extend(
+            {"type": "localImage", "path": str(image_path)} for image_path in batch
+        )
+        turn_params: dict[str, Any] = {
+            "threadId": thread_id,
+            "input": input_items,
+        }
+        if model_name:
+            turn_params["model"] = model_name
+        if effort_name:
+            turn_params["effort"] = effort_name
+        turn_id = _turn_id(client.request("turn/start", params=turn_params))
+        results.append(
+            _collect_turn_text(
+                client,
+                turn_id=turn_id,
+                timeout_seconds=timeout_seconds,
+                requested_model=model_name or None,
             )
-            turn_params: dict[str, Any] = {
-                "threadId": thread_id,
-                "input": input_items,
-            }
-            if model_name:
-                turn_params["model"] = model_name
-            if effort_name:
-                turn_params["effort"] = effort_name
-            turn_id = _turn_id(client.request("turn/start", params=turn_params))
-            results.append(
-                _collect_turn_text(
-                    client,
-                    turn_id=turn_id,
-                    timeout_seconds=timeout_seconds,
-                    requested_model=model_name or None,
-                )
-            )
+        )
     return results
+
+
+def _validate_image_batches(image_batches: list[list[Path]], prompts: list[str]) -> None:
+    if len(image_batches) != len(prompts):
+        raise CodexAppServerError("Image batch and prompt counts do not match")
+    for batch in image_batches:
+        if not batch:
+            raise CodexAppServerError("Image batch cannot be empty")
+        for image_path in batch:
+            if not image_path.exists():
+                raise CodexAppServerError(f"Image path does not exist: {image_path}")
 
 
 def _collect_turn_text(

--- a/src/contextualize/render/markitdown.py
+++ b/src/contextualize/render/markitdown.py
@@ -13,8 +13,11 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 from typing import Any, Mapping, Protocol
 from urllib.parse import urlparse
+
+from ..progress import record_progress
 
 
 class MarkItDownConversionError(RuntimeError):
@@ -205,6 +208,13 @@ class _ImageProviderSelection:
     effective_provider: str
     app_server_live: bool
     app_server_error: str | None
+
+
+_IMAGE_PROVIDER_SELECTION_CACHE: dict[
+    tuple[str, str],
+    _ImageProviderSelection,
+] = {}
+_IMAGE_PROVIDER_SELECTION_LOCK = threading.Lock()
 
 
 def _postprocess_image_markdown(markdown: str) -> str:
@@ -899,44 +909,59 @@ def _resolve_image_provider(
         if requested_mode in _IMAGE_PROVIDER_MODES
         else _DEFAULT_IMAGE_PROVIDER_MODE
     )
+    cache_key = (normalized_mode, app_server_command)
+    with _IMAGE_PROVIDER_SELECTION_LOCK:
+        cached_selection = _IMAGE_PROVIDER_SELECTION_CACHE.get(cache_key)
+    if cached_selection is not None:
+        return cached_selection
+
     if normalized_mode == "openrouter":
         _verbose_log(
             "  image provider selection: mode=openrouter -> provider=openrouter"
         )
-        return _ImageProviderSelection(
+        selection = _ImageProviderSelection(
             requested_mode=normalized_mode,
             effective_provider="openrouter",
             app_server_live=False,
             app_server_error=None,
         )
+        with _IMAGE_PROVIDER_SELECTION_LOCK:
+            _IMAGE_PROVIDER_SELECTION_CACHE[cache_key] = selection
+        return selection
 
-    from .codex import is_codex_app_server_live
+    from .codex import is_shared_codex_app_server_live
 
     _verbose_log(
         "  probing codex app-server for image descriptions: "
         f"mode={normalized_mode} command={app_server_command!r}"
     )
-    is_live, error = is_codex_app_server_live(app_server_command)
+    is_live, error = is_shared_codex_app_server_live(app_server_command)
     if is_live:
         _verbose_log(
             f"  image provider selection: mode={normalized_mode} -> provider=app-server"
         )
-        return _ImageProviderSelection(
+        selection = _ImageProviderSelection(
             requested_mode=normalized_mode,
             effective_provider="app-server",
             app_server_live=True,
             app_server_error=None,
         )
+        with _IMAGE_PROVIDER_SELECTION_LOCK:
+            _IMAGE_PROVIDER_SELECTION_CACHE[cache_key] = selection
+        return selection
     _verbose_log(
         "  image provider selection: "
         f"mode={normalized_mode} -> provider=openrouter (app-server unavailable: {error})"
     )
-    return _ImageProviderSelection(
+    selection = _ImageProviderSelection(
         requested_mode=normalized_mode,
         effective_provider="openrouter",
         app_server_live=False,
         app_server_error=error,
     )
+    with _IMAGE_PROVIDER_SELECTION_LOCK:
+        _IMAGE_PROVIDER_SELECTION_CACHE[cache_key] = selection
+    return selection
 
 
 def _app_server_image_text_from_path(
@@ -949,7 +974,7 @@ def _app_server_image_text_from_path(
 ) -> str:
     from .codex import (
         CodexAppServerError,
-        describe_image_with_codex_app_server,
+        describe_image_with_shared_codex_app_server,
     )
 
     requested_model = _resolve_app_server_request_model(model)
@@ -960,7 +985,7 @@ def _app_server_image_text_from_path(
         f"model={requested_model} effort={effort} endpoint=turn/start"
     )
     try:
-        description_result = describe_image_with_codex_app_server(
+        description_result = describe_image_with_shared_codex_app_server(
             image_path,
             prompt=prompt,
             command=app_server_command,
@@ -977,7 +1002,7 @@ def _app_server_image_text_from_path(
                 "  codex app-server rejected requested model; retrying with default: "
                 f"model={_DEFAULT_CODEX_APP_SERVER_MODEL} effort={effort}"
             )
-            description_result = describe_image_with_codex_app_server(
+            description_result = describe_image_with_shared_codex_app_server(
                 image_path,
                 prompt=prompt,
                 command=app_server_command,
@@ -987,6 +1012,12 @@ def _app_server_image_text_from_path(
             )
         else:
             raise
+    record_progress(
+        "codex-app-server",
+        "image-description",
+        "processed",
+        target=image_path.name,
+    )
     if description_result.rerouted_to_model:
         from_model = description_result.rerouted_from_model or requested_model
         reason = description_result.reroute_reason or "unspecified"
@@ -1295,8 +1326,10 @@ def _image_cache_lookup(
             if requires_llm_description and not _HAS_LLM_DESCRIPTION_RE.search(
                 cached_markdown
             ):
+                record_progress("markitdown", "image-cache", "cache_miss")
                 return key, None
             title = cached_title if isinstance(cached_title, str) else None
+            record_progress("markitdown", "image-cache", "cache_hit")
             return (
                 key,
                 MarkItDownResult(
@@ -1304,6 +1337,7 @@ def _image_cache_lookup(
                     title=title,
                 ),
             )
+    record_progress("markitdown", "image-cache", "cache_miss")
     return key, None
 
 
@@ -1464,7 +1498,7 @@ def _app_server_pdf_batch_texts_from_pages(
 ) -> list[str]:
     from .codex import (
         CodexAppServerError,
-        transcribe_image_batches_with_codex_app_server,
+        transcribe_image_batches_with_shared_codex_app_server,
     )
 
     batches = _chunks(page_paths, batch_size)
@@ -1481,7 +1515,7 @@ def _app_server_pdf_batch_texts_from_pages(
         f"batches={len(batches)} batch_size={batch_size}"
     )
     try:
-        results = transcribe_image_batches_with_codex_app_server(
+        results = transcribe_image_batches_with_shared_codex_app_server(
             batches,
             prompts=prompts,
             command=app_server_command,
@@ -1499,7 +1533,7 @@ def _app_server_pdf_batch_texts_from_pages(
                 f"model={_DEFAULT_CODEX_APP_SERVER_MODEL} effort={effort}"
             )
             try:
-                results = transcribe_image_batches_with_codex_app_server(
+                results = transcribe_image_batches_with_shared_codex_app_server(
                     batches,
                     prompts=prompts,
                     command=app_server_command,
@@ -1518,6 +1552,7 @@ def _app_server_pdf_batch_texts_from_pages(
                 f"{_page_range_label(batches[0])}: {exc}"
             ) from exc
 
+    record_progress("codex-app-server", "pdf-ocr", "processed", count=len(batches))
     for result in results:
         if result.rerouted_to_model:
             from_model = result.rerouted_from_model or requested_model

--- a/src/contextualize/runtime.py
+++ b/src/contextualize/runtime.py
@@ -20,23 +20,41 @@ _SKIP_MEDIA: ContextVar[bool] = ContextVar("contextualize_skip_media", default=F
 _VERBOSE_LOGGING: ContextVar[bool] = ContextVar(
     "contextualize_verbose_logging", default=False
 )
+_PAYLOAD_SPEC_JOBS: ContextVar[int | None] = ContextVar(
+    "contextualize_payload_spec_jobs", default=None
+)
+_PAYLOAD_MEDIA_JOBS: ContextVar[int | None] = ContextVar(
+    "contextualize_payload_media_jobs", default=None
+)
 
-_DEFAULT_PAYLOAD_SPEC_JOBS = 4
-_DEFAULT_PAYLOAD_MEDIA_JOBS = 3
+_DEFAULT_PAYLOAD_SPEC_JOBS = 8
+_DEFAULT_PAYLOAD_MEDIA_JOBS = 4
 _MAX_PAYLOAD_JOBS = 64
+
+
+def normalize_payload_jobs(value: int | str | None, *, default: int) -> int:
+    if value is None:
+        return default
+    if isinstance(value, int):
+        parsed = value
+    else:
+        raw = str(value).strip()
+        if not raw:
+            return default
+        try:
+            parsed = int(raw)
+        except ValueError:
+            return default
+    if parsed <= 0:
+        return default
+    return min(parsed, _MAX_PAYLOAD_JOBS)
 
 
 def _read_positive_int_env(name: str, default: int) -> int:
     raw = (os.environ.get(name) or "").strip()
     if not raw:
         return default
-    try:
-        value = int(raw)
-    except ValueError:
-        return default
-    if value <= 0:
-        return default
-    return min(value, _MAX_PAYLOAD_JOBS)
+    return normalize_payload_jobs(raw, default=default)
 
 
 def get_refresh_images() -> bool:
@@ -128,12 +146,44 @@ def reset_verbose_logging(token: Token[bool]) -> None:
 
 
 def get_payload_spec_jobs() -> int:
+    override = _PAYLOAD_SPEC_JOBS.get()
+    if override is not None:
+        return normalize_payload_jobs(override, default=_DEFAULT_PAYLOAD_SPEC_JOBS)
     return _read_positive_int_env(
         "CONTEXTUALIZE_PAYLOAD_SPEC_JOBS", _DEFAULT_PAYLOAD_SPEC_JOBS
     )
 
 
+def set_payload_spec_jobs(value: int | None) -> Token[int | None]:
+    normalized = (
+        normalize_payload_jobs(value, default=_DEFAULT_PAYLOAD_SPEC_JOBS)
+        if value is not None
+        else None
+    )
+    return _PAYLOAD_SPEC_JOBS.set(normalized)
+
+
+def reset_payload_spec_jobs(token: Token[int | None]) -> None:
+    _PAYLOAD_SPEC_JOBS.reset(token)
+
+
 def get_payload_media_jobs() -> int:
+    override = _PAYLOAD_MEDIA_JOBS.get()
+    if override is not None:
+        return normalize_payload_jobs(override, default=_DEFAULT_PAYLOAD_MEDIA_JOBS)
     return _read_positive_int_env(
         "CONTEXTUALIZE_PAYLOAD_MEDIA_JOBS", _DEFAULT_PAYLOAD_MEDIA_JOBS
     )
+
+
+def set_payload_media_jobs(value: int | None) -> Token[int | None]:
+    normalized = (
+        normalize_payload_jobs(value, default=_DEFAULT_PAYLOAD_MEDIA_JOBS)
+        if value is not None
+        else None
+    )
+    return _PAYLOAD_MEDIA_JOBS.set(normalized)
+
+
+def reset_payload_media_jobs(token: Token[int | None]) -> None:
+    _PAYLOAD_MEDIA_JOBS.reset(token)

--- a/tests/test_codex_app_server.py
+++ b/tests/test_codex_app_server.py
@@ -91,6 +91,98 @@ def test_describe_image_starts_ephemeral_app_server_thread(
     )
 
 
+def test_shared_app_server_reuses_one_process_for_multiple_images(
+    tmp_path: Path, monkeypatch
+) -> None:
+    codex.close_shared_codex_app_server_sessions()
+    image_path = tmp_path / "image.png"
+    image_path.write_bytes(b"png")
+    instances: list[object] = []
+    requests: list[tuple[str, dict[str, Any] | None]] = []
+
+    class _FakeClient:
+        def __init__(self, **_kwargs: Any) -> None:
+            instances.append(self)
+            self._turn_count = 0
+            self._events: list[dict[str, Any]] = []
+
+        def start(self) -> None:
+            return None
+
+        def initialize(self) -> None:
+            requests.append(("initialize", None))
+
+        def close(self) -> None:
+            return None
+
+        def request(
+            self,
+            method: str,
+            *,
+            params: dict[str, Any] | None = None,
+            timeout_seconds: float | None = None,
+        ) -> dict[str, Any]:
+            requests.append((method, params))
+            if method == "model/list":
+                return {}
+            if method == "thread/start":
+                return {"thread": {"id": "thread-1"}}
+            if method == "turn/start":
+                self._turn_count += 1
+                turn_id = f"turn-{self._turn_count}"
+                self._events.extend(
+                    [
+                        {
+                            "method": "item/completed",
+                            "params": {
+                                "item": {
+                                    "type": "agentMessage",
+                                    "text": f"Image {self._turn_count}",
+                                }
+                            },
+                        },
+                        {
+                            "method": "turn/completed",
+                            "params": {
+                                "turn": {"id": turn_id, "status": "completed"}
+                            },
+                        },
+                    ]
+                )
+                return {"turn": {"id": turn_id}}
+            return {}
+
+        def next_event(self, *, timeout_seconds: float | None = None) -> dict[str, Any]:
+            return self._events.pop(0)
+
+    monkeypatch.setattr(codex, "_CodexAppServerClient", _FakeClient)
+
+    try:
+        assert codex.is_shared_codex_app_server_live(
+            "codex app-server --listen stdio://"
+        ) == (
+            True,
+            None,
+        )
+        first = codex.describe_image_with_shared_codex_app_server(
+            image_path,
+            prompt="describe",
+            command="codex app-server --listen stdio://",
+        )
+        second = codex.describe_image_with_shared_codex_app_server(
+            image_path,
+            prompt="describe",
+            command="codex app-server --listen stdio://",
+        )
+    finally:
+        codex.close_shared_codex_app_server_sessions()
+
+    assert [first.text, second.text] == ["Image 1", "Image 2"]
+    assert len(instances) == 1
+    assert [method for method, _params in requests].count("initialize") == 1
+    assert [method for method, _params in requests].count("thread/start") == 2
+
+
 def test_transcribe_image_batches_reuses_one_app_server_thread(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -370,7 +462,7 @@ def test_scanned_pdf_wraps_app_server_batch_timeout(
 
     monkeypatch.setattr(
         codex,
-        "transcribe_image_batches_with_codex_app_server",
+        "transcribe_image_batches_with_shared_codex_app_server",
         fail_batches,
     )
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from contextualize.concurrency import run_indexed_tasks_fail_fast
+
+
+def test_run_indexed_tasks_reports_completion() -> None:
+    seen: list[tuple[int, str]] = []
+
+    results = run_indexed_tasks_fail_fast(
+        [
+            (0, lambda: "a"),
+            (1, lambda: "b"),
+        ],
+        max_workers=1,
+        on_complete=lambda index, result: seen.append((index, result)),
+    )
+
+    assert seen == [(0, "a"), (1, "b")]
+    assert results == [(0, "a"), (1, "b")]

--- a/tests/test_context_registry.py
+++ b/tests/test_context_registry.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 
 from contextualize import cli
 from contextualize.manifest.contexts import ContextHydrationStatus, hydrate_contexts
+from contextualize.progress import record_progress
 
 
 def test_hydrate_context_from_registry_data(tmp_path: Path) -> None:
@@ -290,6 +291,75 @@ def test_contexts_hydrate_prefixes_context_warnings(
     assert result.exit_code == 0
     assert "context demo: hydrated" in result.output
     assert "context demo: Warning: plugin failed" in result.output
+
+
+def test_contexts_hydrate_verbose_reports_progress_summary(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    target_dir = tmp_path / "repo"
+    target_dir.mkdir()
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "contexts": {
+                    "demo": {
+                        "targetDir": str(target_dir),
+                        "manifest": {
+                            "data": {
+                                "config": {"context": {"dir": ".context"}},
+                                "components": [],
+                            }
+                        },
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def _record_and_hydrate(context, _overrides):
+        record_progress("arena", "channel", "cache_hit", target="Cached Channel")
+        return ContextHydrationStatus(
+            name=context.name,
+            target_dir=str(context.target_dir),
+            manifest_source="inline data",
+            context_dir=str(target_dir / ".context"),
+            result="hydrated",
+            reason=None,
+            timestamp="2026-06-04T00:00:00Z",
+        )
+
+    monkeypatch.setattr(
+        "contextualize.manifest.contexts._hydrate_one",
+        _record_and_hydrate,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "--verbose",
+            "contexts",
+            "hydrate",
+            "--registry",
+            str(registry_path),
+            "--status",
+            str(tmp_path / "status.json"),
+            "demo",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "ignoring global options [--verbose]" not in result.output
+    assert "[progress]" not in result.output
+    assert "progress:" not in result.output
+    assert "Progress summary:" in result.output
+    assert "  hydrate context: total=1 done=1" in result.output
+    assert "  context demo:" in result.output
+    assert "    arena channel: cache_hit=1" in result.output
 
 
 def test_hydrate_cli_treats_text_file_with_manifest_block_as_manifest(

--- a/tests/test_hydrate_plugins.py
+++ b/tests/test_hydrate_plugins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import types
 from pathlib import Path
 
@@ -9,6 +10,7 @@ from contextualize.manifest.hydrate import (
     HydrateOverrides,
     apply_hydration_plan,
     build_hydration_plan_data,
+    _resolve_external_items_via_refs,
 )
 from contextualize.plugins import clear_loaded_plugins_cache
 from contextualize.plugins import loader as plugin_loader
@@ -41,6 +43,13 @@ def test_hydrate_manifest_uses_custom_plugin_scheme(
                     },
                 }
             ]
+
+            def classify_target(_target, _context):
+                raise AssertionError(
+                    "hydrate should not classify targets during planning"
+                )
+
+            plugin.classify_target = classify_target
             return plugin
 
     monkeypatch.setattr(
@@ -115,25 +124,487 @@ def test_hydrate_manifest_preserves_colon_plugin_target(
     assert "note/doc.md" in rel_paths
 
 
-def test_hydrate_manifest_follows_component_embedded_targets(
+def test_hydrate_plugin_dedupe_can_skip_noncanonical_paths(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
 
-    class _EmbeddedEntrypoint:
-        name = "embedded"
-        value = "contextualize_plugins.embedded:plugin"
+    class _DedupeEntrypoint:
+        name = "dedupe"
+        value = "contextualize_plugins.dedupe:plugin"
 
         def load(self):
             plugin = types.SimpleNamespace()
             plugin.PLUGIN_API_VERSION = "1"
-            plugin.PLUGIN_NAME = "embedded"
+            plugin.PLUGIN_NAME = "dedupe"
+            plugin.PLUGIN_PRIORITY = 500
+            plugin.can_resolve = lambda target, _context: target == "dedupe://root"
+            plugin.resolve = lambda target, _context: [
+                {
+                    "source": target,
+                    "label": "channel/a.md",
+                    "content": "canonical",
+                    "metadata": {
+                        "context_subpath": "channel/a.md",
+                        "source_ref": "dedupe",
+                        "source_path": "channel/a",
+                        "hydrate_dedupe": {
+                            "mode": "canonical_symlink",
+                            "key": "block:1",
+                            "rank": 0,
+                        },
+                    },
+                },
+                {
+                    "source": target,
+                    "label": "channel/b.md",
+                    "content": "canonical",
+                    "metadata": {
+                        "context_subpath": "channel/b.md",
+                        "source_ref": "dedupe",
+                        "source_path": "channel/b",
+                        "hydrate_dedupe": {
+                            "mode": "canonical_symlink",
+                            "key": "block:1",
+                            "rank": 1,
+                        },
+                    },
+                },
+                {
+                    "source": target,
+                    "label": "flat.md",
+                    "content": "canonical",
+                    "metadata": {
+                        "context_subpath": "flat.md",
+                        "source_ref": "dedupe",
+                        "source_path": "flat",
+                        "hydrate_dedupe": {
+                            "mode": "canonical_symlink",
+                            "key": "block:1",
+                            "rank": 10_000,
+                            "link": False,
+                        },
+                    },
+                },
+            ]
+            return plugin
+
+    monkeypatch.setattr(
+        plugin_loader, "_iter_plugin_entrypoints", lambda: [_DedupeEntrypoint()]
+    )
+    clear_loaded_plugins_cache()
+
+    context_dir = tmp_path / "ctx"
+    plan = build_hydration_plan_data(
+        {
+            "config": {"context": {"dir": str(context_dir), "include-meta": True}},
+            "components": [{"name": "main", "files": ["dedupe://root"]}],
+        },
+        manifest_cwd=str(tmp_path),
+        overrides=HydrateOverrides(),
+        cwd=str(tmp_path),
+    )
+
+    written_paths = {
+        path.relative_to(context_dir).as_posix() for path, _ in plan.files_to_write
+    }
+    symlink_paths = {
+        path.relative_to(context_dir).as_posix()
+        for path, _ in plan.files_to_symlink
+    }
+    index_text = next(
+        content
+        for path, content in plan.files_to_write
+        if path.relative_to(context_dir).as_posix() == "index.json"
+    )
+    index_paths = {
+        entry["context_path"]
+        for entry in json.loads(index_text)["components"]["main"]
+    }
+
+    assert "channel/a.md" in written_paths
+    assert "channel/b.md" in symlink_paths
+    assert "flat.md" not in written_paths
+    assert "flat.md" not in symlink_paths
+    assert "flat.md" not in index_paths
+
+
+
+def test_hydrate_embedded_resolution_targets_inherit_parent_context_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    class _ArenaEntrypoint:
+        name = "arena"
+        value = "contextualize_plugins.arena:plugin"
+
+        def load(self):
+            plugin = types.SimpleNamespace()
+            plugin.PLUGIN_API_VERSION = "1"
+            plugin.PLUGIN_NAME = "arena"
             plugin.PLUGIN_PRIORITY = 500
             plugin.can_resolve = lambda target, _context: target.startswith(
-                ("root://", "asset://")
+                ("root://", "https://www.are.na/block/")
             )
-            plugin.resolve = lambda _target, _context: []
-            plugin.list_targets = lambda _target, _context: {
+
+            def resolve(target: str, _context: dict[str, object]) -> list[dict]:
+                if target != "root://channel":
+                    return []
+                return [
+                    {
+                        "source": target,
+                        "label": "entry-42.md",
+                        "content": "entry 42",
+                        "metadata": {
+                            "provider": "arena",
+                            "block_id": 42,
+                            "block_type": "Link",
+                            "channel_path": "channels/root",
+                            "context_subpath": "channels/root/42.md",
+                            "source_ref": "are.na",
+                            "source_path": "channels/root/42",
+                        },
+                    },
+                    {
+                        "source": target,
+                        "label": "entry-43.md",
+                        "content": "entry 43",
+                        "metadata": {
+                            "provider": "arena",
+                            "block_id": 43,
+                            "block_type": "Link",
+                            "channel_path": "channels/root",
+                            "context_subpath": "channels/root/43.md",
+                            "source_ref": "are.na",
+                            "source_path": "channels/root/43",
+                        },
+                    },
+                ]
+
+            def list_targets(target: str, _context: dict[str, object]) -> dict:
+                if target == "https://www.are.na/block/42":
+                    return {"targets": [{"target": "asset://child", "label": "Child"}]}
+                if target == "https://www.are.na/block/43":
+                    return {"targets": [{"target": "asset://child", "label": "Child again"}]}
+                return {"targets": []}
+
+            plugin.resolve = resolve
+            plugin.list_targets = list_targets
+            return plugin
+
+    class _AssetEntrypoint:
+        name = "asset"
+        value = "contextualize_plugins.asset:plugin"
+
+        def load(self):
+            plugin = types.SimpleNamespace()
+            plugin.PLUGIN_API_VERSION = "1"
+            plugin.PLUGIN_NAME = "asset"
+            plugin.PLUGIN_PRIORITY = 600
+            plugin.can_resolve = lambda target, _context: target == "asset://child"
+            plugin.resolve = lambda target, _context: [
+                {
+                    "source": target,
+                    "label": "asset.md",
+                    "content": "child content",
+                    "metadata": {
+                        "context_subpath": "child.md",
+                        "source_ref": "asset",
+                        "source_path": "child",
+                    },
+                }
+            ]
+            return plugin
+
+    monkeypatch.setattr(
+        plugin_loader,
+        "_iter_plugin_entrypoints",
+        lambda: [_ArenaEntrypoint(), _AssetEntrypoint()],
+    )
+    clear_loaded_plugins_cache()
+
+    context_dir = tmp_path / "ctx"
+    plan = build_hydration_plan_data(
+        {
+            "config": {"context": {"dir": str(context_dir), "include-meta": False}},
+            "components": [
+                {
+                    "name": "main",
+                    "embedded-resolution": True,
+                    "files": ["root://channel"],
+                }
+            ],
+        },
+        manifest_cwd=str(tmp_path),
+        overrides=HydrateOverrides(),
+        cwd=str(tmp_path),
+    )
+
+    assert [
+        (path.relative_to(context_dir).as_posix(), content)
+        for path, content in plan.files_to_write
+    ] == [
+        ("channels/root/42.md", "entry 42"),
+        ("channels/root/43.md", "entry 43"),
+        ("channels/root/42.asset-child.md", "child content"),
+        ("channels/root/43.asset-child.md", "child content"),
+    ]
+
+
+def test_hydrate_embedded_resolution_media_targets_use_parent_sidecar(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    class _ArenaEntrypoint:
+        name = "arena"
+        value = "contextualize_plugins.arena:plugin"
+
+        def load(self):
+            plugin = types.SimpleNamespace()
+            plugin.PLUGIN_API_VERSION = "1"
+            plugin.PLUGIN_NAME = "arena"
+            plugin.PLUGIN_PRIORITY = 500
+            plugin.can_resolve = lambda target, _context: target.startswith(
+                ("root://", "https://www.are.na/block/")
+            )
+            plugin.resolve = lambda target, _context: [
+                {
+                    "source": target,
+                    "label": "entry.md",
+                    "content": "entry content",
+                    "metadata": {
+                        "provider": "arena",
+                        "block_id": 42,
+                        "block_type": "Embed",
+                        "channel_path": "channels/root",
+                        "context_subpath": "channels/root/42.md",
+                        "source_ref": "are.na",
+                        "source_path": "channels/root/42",
+                    },
+                }
+            ] if target == "root://channel" else []
+            plugin.list_targets = lambda target, _context: {
+                "targets": [{"target": "media://child", "label": "Media child"}]
+            } if target == "https://www.are.na/block/42" else {"targets": []}
+            return plugin
+
+    class _YtdlpEntrypoint:
+        name = "ytdlp"
+        value = "contextualize_plugins.ytdlp:plugin"
+
+        def load(self):
+            plugin = types.SimpleNamespace()
+            plugin.PLUGIN_API_VERSION = "1"
+            plugin.PLUGIN_NAME = "ytdlp"
+            plugin.PLUGIN_PRIORITY = 600
+            plugin.can_resolve = lambda target, _context: target == "media://child"
+            plugin.resolve = lambda target, _context: [
+                {
+                    "source": target,
+                    "label": "Video",
+                    "content": "media transcript",
+                    "metadata": {
+                        "context_subpath": "ytdlp-youtube-abc123.md",
+                        "source_ref": "www.youtube.com",
+                        "source_path": "youtube:abc123",
+                    },
+                }
+            ]
+            return plugin
+
+    monkeypatch.setattr(
+        plugin_loader,
+        "_iter_plugin_entrypoints",
+        lambda: [_ArenaEntrypoint(), _YtdlpEntrypoint()],
+    )
+    clear_loaded_plugins_cache()
+
+    context_dir = tmp_path / "ctx"
+    plan = build_hydration_plan_data(
+        {
+            "config": {"context": {"dir": str(context_dir), "include-meta": False}},
+            "components": [
+                {
+                    "name": "main",
+                    "embedded-resolution": True,
+                    "files": ["root://channel"],
+                }
+            ],
+        },
+        manifest_cwd=str(tmp_path),
+        overrides=HydrateOverrides(),
+        cwd=str(tmp_path),
+    )
+
+    assert [
+        (path.relative_to(context_dir).as_posix(), content)
+        for path, content in plan.files_to_write
+    ] == [
+        ("channels/root/42.md", "entry content"),
+        ("channels/root/42.ytdlp-youtube-abc123.md", "media transcript"),
+    ]
+
+
+def test_hydrate_embedded_resolution_arena_attachment_uses_dot_sidecar(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    class _ArenaEntrypoint:
+        name = "arena"
+        value = "contextualize_plugins.arena:plugin"
+
+        def load(self):
+            plugin = types.SimpleNamespace()
+            plugin.PLUGIN_API_VERSION = "1"
+            plugin.PLUGIN_NAME = "arena"
+            plugin.PLUGIN_PRIORITY = 500
+            plugin.can_resolve = lambda target, _context: target.startswith(
+                ("root://", "attachment://", "https://www.are.na/block/")
+            )
+
+            def resolve(target: str, _context: dict[str, object]) -> list[dict]:
+                if target == "root://channel":
+                    return [
+                        {
+                            "source": target,
+                            "label": "entry.md",
+                            "content": "entry content",
+                            "metadata": {
+                                "provider": "arena",
+                                "block_id": 42,
+                                "block_type": "Attachment",
+                                "channel_path": "channels/root",
+                                "context_subpath": "channels/root/42.md",
+                                "source_ref": "are.na",
+                                "source_path": "channels/root/42",
+                            },
+                        }
+                    ]
+                if target == "attachment://child":
+                    return [
+                        {
+                            "source": target,
+                            "label": "attachment-video.mp4.md",
+                            "content": "attachment content",
+                            "metadata": {
+                                "context_subpath": (
+                                    "arena-block-42/attachment-video.mp4.mp4.md"
+                                ),
+                                "source_ref": "are.na",
+                                "source_path": "42/attachment/video.mp4",
+                            },
+                        }
+                    ]
+                return []
+
+            plugin.resolve = resolve
+            plugin.list_targets = lambda target, _context: {
+                "targets": [{"target": "attachment://child", "label": "Attachment"}]
+            } if target == "https://www.are.na/block/42" else {"targets": []}
+            return plugin
+
+    monkeypatch.setattr(
+        plugin_loader, "_iter_plugin_entrypoints", lambda: [_ArenaEntrypoint()]
+    )
+    clear_loaded_plugins_cache()
+
+    context_dir = tmp_path / "ctx"
+    plan = build_hydration_plan_data(
+        {
+            "config": {"context": {"dir": str(context_dir), "include-meta": False}},
+            "components": [
+                {
+                    "name": "main",
+                    "embedded-resolution": True,
+                    "files": ["root://channel"],
+                }
+            ],
+        },
+        manifest_cwd=str(tmp_path),
+        overrides=HydrateOverrides(),
+        cwd=str(tmp_path),
+    )
+
+    assert [
+        (path.relative_to(context_dir).as_posix(), content)
+        for path, content in plan.files_to_write
+    ] == [
+        ("channels/root/42.md", "entry content"),
+        ("channels/root/42.attachment-video.mp4.mp4.md", "attachment content"),
+    ]
+
+
+def test_hydrate_embedded_resolution_http_refs_use_ref_path_and_dot_sidecar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Ref:
+        path = "https://example.com/assets/doc.txt"
+        file_content = "doc content"
+        _contextualize_context_prefix = "channels/root/42"
+        _contextualize_context_sidecar_stem = "channels/root/42"
+
+    monkeypatch.setattr(
+        "contextualize.manifest.hydrate.create_file_references",
+        lambda *_args, **_kwargs: {"refs": [_Ref()]},
+    )
+
+    items = _resolve_external_items_via_refs(
+        "root://channel",
+        alias=None,
+        embedded_resolution=True,
+    )
+
+    assert len(items) == 1
+    assert items[0].source_type == "http"
+    assert items[0].source_ref == "https://example.com"
+    assert items[0].source_path == "assets/doc.txt"
+    assert items[0].context_subpath == "channels/root/42.doc.txt.md"
+    assert items[0].manifest_spec == "https://example.com/assets/doc.txt"
+
+
+def test_hydrate_manifest_embedded_resolution_materializes_embedded_targets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    class _ArenaEntrypoint:
+        name = "arena"
+        value = "contextualize_plugins.arena:plugin"
+
+        def load(self):
+            plugin = types.SimpleNamespace()
+            plugin.PLUGIN_API_VERSION = "1"
+            plugin.PLUGIN_NAME = "arena"
+            plugin.PLUGIN_PRIORITY = 500
+            plugin.can_resolve = lambda target, _context: target.startswith(
+                ("root://", "asset://", "https://www.are.na/block/")
+            )
+
+            def resolve(target: str, _context: dict[str, object]) -> list[dict]:
+                if target == "root://thread":
+                    return [
+                        {
+                            "source": target,
+                            "label": "entry.md",
+                            "content": "entry content",
+                            "metadata": {
+                                "provider": "arena",
+                                "block_id": 42,
+                                "block_type": "Link",
+                                "channel_path": "thread",
+                                "context_subpath": "thread/42.md",
+                                "source_ref": "are.na",
+                                "source_path": "thread/42",
+                            },
+                        }
+                    ]
+                return []
+
+            plugin.resolve = resolve
+            plugin.list_targets = lambda target, _context: {
                 "targets": [
                     {"target": "asset://child", "label": "child.txt"},
                     {
@@ -143,7 +614,7 @@ def test_hydrate_manifest_follows_component_embedded_targets(
                         "traverse": False,
                     },
                 ]
-            }
+            } if target == "https://www.are.na/block/42" else {"targets": []}
 
             def materialize(target: str, _context: dict[str, object]) -> list[dict]:
                 if target != "asset://child":
@@ -162,7 +633,7 @@ def test_hydrate_manifest_follows_component_embedded_targets(
             return plugin
 
     monkeypatch.setattr(
-        plugin_loader, "_iter_plugin_entrypoints", lambda: [_EmbeddedEntrypoint()]
+        plugin_loader, "_iter_plugin_entrypoints", lambda: [_ArenaEntrypoint()]
     )
     clear_loaded_plugins_cache()
 
@@ -179,8 +650,7 @@ def test_hydrate_manifest_follows_component_embedded_targets(
             "components": [
                 {
                     "name": "main",
-                    "target-depth": 1,
-                    "include-parent": False,
+                    "embedded-resolution": True,
                     "files": ["root://thread"],
                 }
             ],
@@ -193,8 +663,10 @@ def test_hydrate_manifest_follows_component_embedded_targets(
     assert [
         (path.relative_to(context_dir).as_posix(), content)
         for path, content in plan.files_to_write
-    ] == [("main/child.txt", "child content")]
-
+    ] == [
+        ("main/thread/42.md", "entry content"),
+        ("main/thread/42.materialized-child.txt.md", "child content"),
+    ]
 
 def test_hydrate_git_target_copies_binary_files_without_resolving_references(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/test_local_media_cache.py
+++ b/tests/test_local_media_cache.py
@@ -8,6 +8,7 @@ import pytest
 from contextualize.cache import local_media as local_media_cache
 from contextualize.plugins.api import (
     TranscriptionProvider,
+    TranscriptionProviderError,
     TranscriptionRequest,
     TranscriptionResult,
 )
@@ -15,6 +16,7 @@ from contextualize.run_metadata import flush_run_metadata, reset_run_metadata
 from contextualize.runtime import reset_verbose_logging, set_verbose_logging
 from contextualize.transcription import (
     transcribe_audio_file,
+    transcribe_media_bytes,
     transcribe_media_file,
     transcription_routing_identity,
     transcription_routing_summary,
@@ -190,6 +192,68 @@ def test_transcribe_audio_file_refresh_cache_bypasses_cached_result(
     assert transcribe_audio_file(audio_path) == "audio transcript 1"
     assert transcribe_audio_file(audio_path, refresh_cache=True) == "audio transcript 2"
     assert calls == [1, 2]
+
+
+def test_transcribe_audio_file_refresh_cache_uses_stale_cache_on_transient_error(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _configure_local_media_cache(tmp_path, monkeypatch)
+    audio_path = tmp_path / "clip.mp3"
+    audio_path.write_bytes(b"audio")
+
+    def _transcribe(_request: TranscriptionRequest) -> TranscriptionResult:
+        return TranscriptionResult(
+            text="audio transcript",
+            model="openai",
+            provider="openai",
+        )
+
+    monkeypatch.setattr(
+        "contextualize.references.audio_transcription.loaded_transcription_providers",
+        lambda: (_provider("openai", _transcribe),),
+    )
+    assert transcribe_audio_file(audio_path) == "audio transcript"
+
+    calls: list[int] = []
+
+    def _rate_limited(_request: TranscriptionRequest) -> TranscriptionResult:
+        calls.append(1)
+        raise TranscriptionProviderError(
+            'OpenAI-compatible transcription failed: 429 {"error":{"message":"transcription queue is full"}}'
+        )
+
+    monkeypatch.setattr(
+        "contextualize.references.audio_transcription.loaded_transcription_providers",
+        lambda: (_provider("openai", _rate_limited),),
+    )
+
+    assert transcribe_audio_file(audio_path, refresh_cache=True) == "audio transcript"
+    assert calls == [1]
+
+
+def test_transcribe_media_bytes_reuses_audio_cache(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _configure_local_media_cache(tmp_path, monkeypatch)
+    calls: list[int] = []
+
+    def _transcribe(request: TranscriptionRequest) -> TranscriptionResult:
+        calls.append(1)
+        assert request.data == b"audio"
+        return TranscriptionResult(
+            text=f"audio transcript {len(calls)}",
+            model="openai",
+            provider="openai",
+        )
+
+    monkeypatch.setattr(
+        "contextualize.references.audio_transcription.loaded_transcription_providers",
+        lambda: (_provider("openai", _transcribe),),
+    )
+
+    assert transcribe_media_bytes(b"audio", filename="clip.mp3") == "audio transcript 1"
+    assert transcribe_media_bytes(b"audio", filename="renamed.mp3") == "audio transcript 1"
+    assert calls == [1]
 
 
 def test_transcribe_audio_file_passes_language_override(

--- a/tests/test_media_transcription_cutover.py
+++ b/tests/test_media_transcription_cutover.py
@@ -108,10 +108,12 @@ def test_url_reference_uses_video_context_for_video_content_type(
         filename: str,
         content_type: str | None = None,
         timeout: float | None = None,
+        refresh_cache: bool | None = None,
         source_url: str | None = None,
     ) -> str:
         assert data == b"video-bytes"
         assert timeout is None
+        assert refresh_cache is False
         captured["filename"] = filename
         captured["content_type"] = content_type or ""
         captured["source_url"] = source_url or ""
@@ -154,6 +156,7 @@ def test_url_reference_media_transcription_failure_is_error(
         filename: str,
         content_type: str | None = None,
         timeout: float | None = None,
+        refresh_cache: bool | None = None,
         source_url: str | None = None,
     ) -> str:
         raise RuntimeError("broken")
@@ -164,6 +167,56 @@ def test_url_reference_media_transcription_failure_is_error(
 
     with pytest.raises(ValueError, match="Media transcription failed for"):
         URLReference(url=url, format="raw", use_cache=False)
+
+
+def test_url_reference_passes_audio_refresh_to_transcription(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    url = "https://example.com/audio.mp3"
+    captured: dict[str, object] = {}
+
+    def _head_fail(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise requests.RequestException("head failed")
+
+    def _get_audio(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return _DummyResponse(
+            status_code=200,
+            headers={"Content-Type": "audio/mpeg"},
+            content=b"audio-bytes",
+            url=url,
+        )
+
+    def _transcribe(
+        data: bytes,
+        *,
+        filename: str,
+        content_type: str | None = None,
+        refresh_cache: bool | None = None,
+        plugin_overrides: dict[str, object] | None = None,
+    ) -> str:
+        captured["data"] = data
+        captured["filename"] = filename
+        captured["content_type"] = content_type
+        captured["refresh_cache"] = refresh_cache
+        captured["plugin_overrides"] = plugin_overrides
+        return "audio transcript"
+
+    monkeypatch.setattr(requests, "head", _head_fail)
+    monkeypatch.setattr(requests, "get", _get_audio)
+    monkeypatch.setattr(
+        "contextualize.references.url.transcribe_media_bytes", _transcribe
+    )
+
+    ref = URLReference(url=url, format="raw", use_cache=False, refresh_cache=True)
+
+    assert ref.read() == "audio transcript"
+    assert captured == {
+        "data": b"audio-bytes",
+        "filename": "audio.mp3",
+        "content_type": "audio/mpeg",
+        "refresh_cache": True,
+        "plugin_overrides": None,
+    }
 
 
 def test_url_reference_video_cache_varies_by_video_overrides(
@@ -193,6 +246,7 @@ def test_url_reference_video_cache_varies_by_video_overrides(
         filename: str,
         content_type: str | None = None,
         timeout: float | None = None,
+        refresh_cache: bool | None = None,
         source_url: str | None = None,
         plugin_overrides: dict[str, object] | None = None,
     ) -> str:

--- a/tests/test_plugin_cli_options.py
+++ b/tests/test_plugin_cli_options.py
@@ -11,6 +11,8 @@ from contextualize import cli
 from contextualize.plugins import clear_loaded_plugins_cache
 from contextualize.plugins import loader as plugin_loader
 from contextualize.runtime import (
+    get_payload_media_jobs,
+    get_payload_spec_jobs,
     get_refresh_audio,
     reset_refresh_audio,
     set_refresh_audio,
@@ -85,6 +87,41 @@ def test_cat_passes_plugin_cli_overrides_into_file_reference_creation(
 
     assert result.exit_code == 0
     assert captured["plugin_overrides"] == {"demo-cli": {"value": "hello"}}
+
+
+def test_cat_accepts_forwarded_parallel_job_options(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(plugin_loader, "_iter_plugin_entrypoints", lambda: [])
+    clear_loaded_plugins_cache()
+
+    note_path = tmp_path / "note.txt"
+    note_path.write_text("hello", encoding="utf-8")
+    captured: dict[str, int] = {}
+
+    def _create_file_references(*args, **kwargs):
+        captured["spec_jobs"] = get_payload_spec_jobs()
+        captured["media_jobs"] = get_payload_media_jobs()
+        return {
+            "refs": [],
+            "concatenated": "",
+            "ignored_files": [],
+            "ignored_folders": {},
+        }
+
+    monkeypatch.setattr(
+        "contextualize.references.create_file_references", _create_file_references
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["--spec-jobs", "7", "--media-jobs", "5", "cat", str(note_path)],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {"spec_jobs": 7, "media_jobs": 5}
 
 
 def test_cat_merges_video_cli_overrides_into_file_reference_creation(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -257,39 +257,58 @@ def test_injected_http_target_uses_plugin_and_inherits_cache_flags(
     )
 
 
-def test_embedded_target_materialization_uses_normal_file_resolver(
+
+def test_embedded_resolution_materialization_uses_normal_file_resolver(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     _reset_plugin_env(monkeypatch, tmp_path)
 
-    class _EmbeddedEntrypoint:
-        name = "embedded"
-        value = "contextualize_plugins.embedded:plugin"
+    class _ArenaEntrypoint:
+        name = "arena"
+        value = "contextualize_plugins.arena:plugin"
 
         def load(self):
             plugin = types.SimpleNamespace()
             plugin.PLUGIN_API_VERSION = "1"
-            plugin.PLUGIN_NAME = "embedded"
+            plugin.PLUGIN_NAME = "arena"
             plugin.PLUGIN_PRIORITY = 500
             plugin.can_resolve = lambda target, _context: target.startswith(
-                ("root://", "asset://")
+                ("root://", "asset://", "https://www.are.na/block/")
             )
 
             def resolve(target: str, _context: dict[str, object]) -> list[dict]:
-                if target.startswith("root://"):
-                    raise AssertionError("parent should not be resolved")
+                if target == "root://channel":
+                    return [
+                        {
+                            "source": target,
+                            "label": "entry.md",
+                            "content": "entry content",
+                            "metadata": {
+                                "provider": "arena",
+                                "block_id": 42,
+                                "block_type": "Link",
+                                "channel_path": "channels/root",
+                                "context_subpath": "channels/root/42.md",
+                            },
+                        }
+                    ]
                 return []
 
+            def list_targets(target: str, _context: dict[str, object]) -> dict:
+                if target != "https://www.are.na/block/42":
+                    return {"targets": []}
+                return {
+                    "targets": [
+                        {
+                            "target": "asset://child",
+                            "label": "child.md",
+                            "kind": "attachment:text",
+                        }
+                    ]
+                }
+
             plugin.resolve = resolve
-            plugin.list_targets = lambda _target, _context: {
-                "targets": [
-                    {
-                        "target": "asset://child",
-                        "label": "child.md",
-                        "kind": "attachment:text",
-                    }
-                ]
-            }
+            plugin.list_targets = list_targets
             plugin.materialize = lambda _target, _context: [
                 {
                     "source": "asset://child",
@@ -302,46 +321,270 @@ def test_embedded_target_materialization_uses_normal_file_resolver(
             return plugin
 
     monkeypatch.setattr(
-        plugin_loader, "_iter_plugin_entrypoints", lambda: [_EmbeddedEntrypoint()]
+        plugin_loader, "_iter_plugin_entrypoints", lambda: [_ArenaEntrypoint()]
     )
     clear_loaded_plugins_cache()
 
     result = create_file_references(
-        ["root://thread"],
+        ["root://channel"],
         format="raw",
-        target_depth=1,
-        include_parent=False,
+        embedded_resolution=True,
     )
 
-    assert result["concatenated"] == "child content"
+    assert result["concatenated"] == "entry content\n\nchild content"
 
 
-def test_embedded_target_resolves_plugin_claimed_child_without_materialization(
+def test_embedded_resolution_lists_direct_plugin_parent(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     _reset_plugin_env(monkeypatch, tmp_path)
+    listed: list[str] = []
 
-    class _EmbeddedEntrypoint:
-        name = "embedded"
-        value = "contextualize_plugins.embedded:plugin"
+    class _DirectEntrypoint:
+        name = "direct"
+        value = "contextualize_plugins.direct:plugin"
 
         def load(self):
             plugin = types.SimpleNamespace()
             plugin.PLUGIN_API_VERSION = "1"
-            plugin.PLUGIN_NAME = "embedded"
+            plugin.PLUGIN_NAME = "direct"
             plugin.PLUGIN_PRIORITY = 500
             plugin.can_resolve = lambda target, _context: target.startswith(
-                ("root://", "child://")
+                ("direct://", "asset://")
             )
 
             def resolve(target: str, _context: dict[str, object]) -> list[dict]:
-                if target.startswith("root://"):
-                    raise AssertionError("parent should not be resolved")
+                if target != "direct://message":
+                    return []
                 return [
                     {
                         "source": target,
-                        "label": "child.md",
-                        "content": "child content",
+                        "label": "message.md",
+                        "content": "message content",
+                        "metadata": {
+                            "provider": "direct",
+                            "context_subpath": "messages/message.md",
+                        },
+                    }
+                ]
+
+            def list_targets(target: str, _context: dict[str, object]) -> dict:
+                listed.append(target)
+                return {
+                    "targets": [
+                        {
+                            "target": "asset://attachment",
+                            "label": "attachment.md",
+                        }
+                    ]
+                }
+
+            plugin.resolve = resolve
+            plugin.list_targets = list_targets
+            plugin.materialize = lambda _target, _context: [
+                {
+                    "source": "asset://attachment",
+                    "label": "attachment.md",
+                    "filename": "attachment.md",
+                    "content": b"attachment content",
+                    "content_type": "text/markdown",
+                }
+            ]
+            return plugin
+
+    monkeypatch.setattr(
+        plugin_loader, "_iter_plugin_entrypoints", lambda: [_DirectEntrypoint()]
+    )
+    clear_loaded_plugins_cache()
+
+    result = create_file_references(
+        ["direct://message"],
+        format="raw",
+        embedded_resolution=True,
+    )
+
+    assert listed == ["direct://message"]
+    assert result["concatenated"] == "message content\n\nattachment content"
+
+
+def test_embedded_resolution_text_only_materialized_audio_is_transcribed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _reset_plugin_env(monkeypatch, tmp_path)
+    transcribed: list[str] = []
+
+    class _ArenaEntrypoint:
+        name = "arena"
+        value = "contextualize_plugins.arena:plugin"
+
+        def load(self):
+            plugin = types.SimpleNamespace()
+            plugin.PLUGIN_API_VERSION = "1"
+            plugin.PLUGIN_NAME = "arena"
+            plugin.PLUGIN_PRIORITY = 500
+            plugin.can_resolve = lambda target, _context: target.startswith(
+                ("root://", "asset://", "https://www.are.na/block/")
+            )
+
+            def resolve(target: str, _context: dict[str, object]) -> list[dict]:
+                if target != "root://channel":
+                    return []
+                return [
+                    {
+                        "source": target,
+                        "label": "entry.md",
+                        "content": "entry content",
+                        "metadata": {
+                            "provider": "arena",
+                            "block_id": 42,
+                            "block_type": "Attachment",
+                            "channel_path": "channels/root",
+                            "context_subpath": "channels/root/42.md",
+                        },
+                    }
+                ]
+
+            plugin.resolve = resolve
+            plugin.list_targets = lambda _target, _context: {
+                "targets": [{"target": "asset://child", "label": "child.mp3"}]
+            }
+            plugin.materialize = lambda _target, _context: [
+                {
+                    "source": "asset://child",
+                    "label": "child.mp3",
+                    "filename": "child.mp3",
+                    "content": b"\xffaudio",
+                    "content_type": "audio/mpeg",
+                }
+            ]
+            return plugin
+
+    def _transcribe(path: str | Path, **_kwargs) -> str:
+        transcribed.append(Path(path).name)
+        return "audio transcript"
+
+    monkeypatch.setattr(
+        plugin_loader, "_iter_plugin_entrypoints", lambda: [_ArenaEntrypoint()]
+    )
+    monkeypatch.setattr(
+        "contextualize.references.file.transcribe_media_file", _transcribe
+    )
+    clear_loaded_plugins_cache()
+
+    result = create_file_references(
+        ["root://channel"],
+        format="raw",
+        embedded_resolution=True,
+        text_only=True,
+    )
+
+    captured = capsys.readouterr()
+    assert result["concatenated"] == "entry content\n\naudio transcript"
+    assert transcribed == ["child.mp3"]
+    assert captured.err == ""
+
+
+def test_embedded_resolution_materialized_unknown_binary_is_skipped(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _reset_plugin_env(monkeypatch, tmp_path)
+
+    class _ArenaEntrypoint:
+        name = "arena"
+        value = "contextualize_plugins.arena:plugin"
+
+        def load(self):
+            plugin = types.SimpleNamespace()
+            plugin.PLUGIN_API_VERSION = "1"
+            plugin.PLUGIN_NAME = "arena"
+            plugin.PLUGIN_PRIORITY = 500
+            plugin.can_resolve = lambda target, _context: target.startswith(
+                ("root://", "asset://", "https://www.are.na/block/")
+            )
+
+            def resolve(target: str, _context: dict[str, object]) -> list[dict]:
+                if target != "root://channel":
+                    return []
+                return [
+                    {
+                        "source": target,
+                        "label": "entry.md",
+                        "content": "entry content",
+                        "metadata": {
+                            "provider": "arena",
+                            "block_id": 42,
+                            "block_type": "Attachment",
+                            "channel_path": "channels/root",
+                            "context_subpath": "channels/root/42.md",
+                        },
+                    }
+                ]
+
+            plugin.resolve = resolve
+            plugin.list_targets = lambda _target, _context: {
+                "targets": [{"target": "asset://child", "label": "child.bin"}]
+            }
+            plugin.materialize = lambda _target, _context: [
+                {
+                    "source": "asset://child",
+                    "label": "child.bin",
+                    "filename": "child.bin",
+                    "content": b"\xff\x00binary",
+                    "content_type": "application/octet-stream",
+                }
+            ]
+            return plugin
+
+    monkeypatch.setattr(
+        plugin_loader, "_iter_plugin_entrypoints", lambda: [_ArenaEntrypoint()]
+    )
+    clear_loaded_plugins_cache()
+
+    result = create_file_references(
+        ["root://channel"],
+        format="raw",
+        embedded_resolution=True,
+        text_only=True,
+    )
+
+    captured = capsys.readouterr()
+    assert result["concatenated"] == "entry content"
+    assert captured.err == ""
+
+
+def test_embedded_resolution_resolves_plugin_claimed_child_without_materialization(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _reset_plugin_env(monkeypatch, tmp_path)
+
+    class _ArenaEntrypoint:
+        name = "arena"
+        value = "contextualize_plugins.arena:plugin"
+
+        def load(self):
+            plugin = types.SimpleNamespace()
+            plugin.PLUGIN_API_VERSION = "1"
+            plugin.PLUGIN_NAME = "arena"
+            plugin.PLUGIN_PRIORITY = 500
+            plugin.can_resolve = lambda target, _context: target.startswith(
+                ("root://", "https://www.are.na/block/")
+            )
+
+            def resolve(target: str, _context: dict[str, object]) -> list[dict]:
+                if target != "root://channel":
+                    return []
+                return [
+                    {
+                        "source": target,
+                        "label": "entry.md",
+                        "content": "entry content",
+                        "metadata": {
+                            "provider": "arena",
+                            "block_id": 42,
+                            "block_type": "Link",
+                            "channel_path": "channels/root",
+                            "context_subpath": "channels/root/42.md",
+                        },
                     }
                 ]
 
@@ -349,156 +592,184 @@ def test_embedded_target_resolves_plugin_claimed_child_without_materialization(
             plugin.list_targets = lambda _target, _context: {
                 "targets": [{"target": "child://one", "label": "child.md"}]
             }
+            return plugin
+
+    class _ChildEntrypoint:
+        name = "child"
+        value = "contextualize_plugins.child:plugin"
+
+        def load(self):
+            plugin = types.SimpleNamespace()
+            plugin.PLUGIN_API_VERSION = "1"
+            plugin.PLUGIN_NAME = "child"
+            plugin.PLUGIN_PRIORITY = 600
+            plugin.can_resolve = lambda target, _context: target.startswith("child://")
+            plugin.resolve = lambda target, _context: [
+                {
+                    "source": target,
+                    "label": "child.md",
+                    "content": "child content",
+                }
+            ]
             plugin.materialize = lambda _target, _context: pytest.fail(
                 "resolved plugin children should not be materialized"
             )
             return plugin
 
     monkeypatch.setattr(
-        plugin_loader, "_iter_plugin_entrypoints", lambda: [_EmbeddedEntrypoint()]
+        plugin_loader,
+        "_iter_plugin_entrypoints",
+        lambda: [_ArenaEntrypoint(), _ChildEntrypoint()],
     )
     clear_loaded_plugins_cache()
 
     result = create_file_references(
-        ["root://thread"],
+        ["root://channel"],
         format="raw",
-        target_depth=1,
-        include_parent=False,
+        embedded_resolution=True,
     )
 
-    assert result["concatenated"] == "child content"
+    assert result["concatenated"] == "entry content\n\nchild content"
 
 
-def test_embedded_target_depth_skips_non_traversable_items(
+def test_embedded_resolution_does_not_recurse_child_targets(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     _reset_plugin_env(monkeypatch, tmp_path)
 
-    class _EmbeddedEntrypoint:
-        name = "embedded"
-        value = "contextualize_plugins.embedded:plugin"
+    class _ArenaEntrypoint:
+        name = "arena"
+        value = "contextualize_plugins.arena:plugin"
 
         def load(self):
             plugin = types.SimpleNamespace()
             plugin.PLUGIN_API_VERSION = "1"
-            plugin.PLUGIN_NAME = "embedded"
+            plugin.PLUGIN_NAME = "arena"
             plugin.PLUGIN_PRIORITY = 500
             plugin.can_resolve = lambda target, _context: target.startswith(
-                ("root://", "block://", "channel://")
+                ("root://", "https://www.are.na/block/")
             )
 
             def resolve(target: str, _context: dict[str, object]) -> list[dict]:
-                if target.startswith("root://") or target.startswith("channel://"):
-                    raise AssertionError(f"unexpected target resolution: {target}")
+                if target != "root://channel":
+                    return []
                 return [
                     {
                         "source": target,
-                        "label": target.removeprefix("block://") + ".md",
-                        "content": target.removeprefix("block://") + " content",
+                        "label": "entry.md",
+                        "content": "entry content",
+                        "metadata": {
+                            "provider": "arena",
+                            "block_id": 42,
+                            "block_type": "Link",
+                            "channel_path": "channels/root",
+                            "context_subpath": "channels/root/42.md",
+                        },
                     }
                 ]
-
-            def list_targets(target: str, _context: dict[str, object]) -> dict:
-                if target == "root://thread":
-                    return {
-                        "targets": [
-                            {"target": "block://child", "label": "child.md"},
-                            {
-                                "target": "channel://nested",
-                                "label": "nested",
-                                "kind": "channel",
-                                "traverse": False,
-                            },
-                        ]
-                    }
-                if target == "block://child":
-                    return {
-                        "targets": [
-                            {"target": "block://grandchild", "label": "grandchild.md"}
-                        ]
-                    }
-                return {"targets": []}
 
             plugin.resolve = resolve
-            plugin.list_targets = list_targets
-            return plugin
-
-    monkeypatch.setattr(
-        plugin_loader, "_iter_plugin_entrypoints", lambda: [_EmbeddedEntrypoint()]
-    )
-    clear_loaded_plugins_cache()
-
-    result = create_file_references(
-        ["root://thread"],
-        format="raw",
-        target_depth=2,
-        include_parent=False,
-    )
-
-    assert result["concatenated"] == "child content\n\ngrandchild content"
-
-
-def test_embedded_target_skips_unclaimed_plain_http_link(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    _reset_plugin_env(monkeypatch, tmp_path)
-
-    class _EmbeddedEntrypoint:
-        name = "embedded"
-        value = "contextualize_plugins.embedded:plugin"
-
-        def load(self):
-            plugin = types.SimpleNamespace()
-            plugin.PLUGIN_API_VERSION = "1"
-            plugin.PLUGIN_NAME = "embedded"
-            plugin.PLUGIN_PRIORITY = 500
-            plugin.can_resolve = lambda target, _context: target.startswith("root://")
-            plugin.resolve = lambda _target, _context: []
             plugin.list_targets = lambda _target, _context: {
-                "targets": [
-                    {
-                        "target": "https://x.com/example/status/1?s=20",
-                        "label": "tweet",
-                    }
-                ]
+                "targets": [{"target": "child://one", "label": "child.md"}]
             }
             return plugin
 
-    def _url_reference(*_args, **_kwargs):
-        raise AssertionError("plain embedded links should not be fetched directly")
-
-    monkeypatch.setattr(
-        plugin_loader, "_iter_plugin_entrypoints", lambda: [_EmbeddedEntrypoint()]
-    )
-    monkeypatch.setattr(reference_factory, "URLReference", _url_reference)
-    clear_loaded_plugins_cache()
-
-    result = create_file_references(
-        ["root://thread"],
-        format="raw",
-        target_depth=1,
-        include_parent=False,
-    )
-
-    assert result["concatenated"] == ""
-
-
-def test_embedded_target_allows_file_like_http_link(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    _reset_plugin_env(monkeypatch, tmp_path)
-
-    class _EmbeddedEntrypoint:
-        name = "embedded"
-        value = "contextualize_plugins.embedded:plugin"
+    class _ChildEntrypoint:
+        name = "child"
+        value = "contextualize_plugins.child:plugin"
 
         def load(self):
             plugin = types.SimpleNamespace()
             plugin.PLUGIN_API_VERSION = "1"
-            plugin.PLUGIN_NAME = "embedded"
+            plugin.PLUGIN_NAME = "child"
+            plugin.PLUGIN_PRIORITY = 600
+            plugin.can_resolve = lambda target, _context: target.startswith("child://")
+            plugin.resolve = lambda target, _context: [
+                {
+                    "source": target,
+                    "label": "child.md",
+                    "content": "child content",
+                }
+            ]
+            plugin.list_targets = lambda _target, _context: {
+                "targets": [{"target": "grandchild://one", "label": "grandchild.md"}]
+            }
+            return plugin
+
+    class _GrandchildEntrypoint:
+        name = "grandchild"
+        value = "contextualize_plugins.grandchild:plugin"
+
+        def load(self):
+            plugin = types.SimpleNamespace()
+            plugin.PLUGIN_API_VERSION = "1"
+            plugin.PLUGIN_NAME = "grandchild"
+            plugin.PLUGIN_PRIORITY = 700
+            plugin.can_resolve = lambda target, _context: target.startswith(
+                "grandchild://"
+            )
+            plugin.resolve = lambda _target, _context: [
+                {
+                    "source": "grandchild://one",
+                    "label": "grandchild.md",
+                    "content": "grandchild content",
+                }
+            ]
+            return plugin
+
+    monkeypatch.setattr(
+        plugin_loader,
+        "_iter_plugin_entrypoints",
+        lambda: [_ArenaEntrypoint(), _ChildEntrypoint(), _GrandchildEntrypoint()],
+    )
+    clear_loaded_plugins_cache()
+
+    result = create_file_references(
+        ["root://channel"],
+        format="raw",
+        embedded_resolution=True,
+    )
+
+    assert result["concatenated"] == "entry content\n\nchild content"
+
+
+def test_embedded_resolution_skips_unclaimed_http_link(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _reset_plugin_env(monkeypatch, tmp_path)
+
+    class _ArenaEntrypoint:
+        name = "arena"
+        value = "contextualize_plugins.arena:plugin"
+
+        def load(self):
+            plugin = types.SimpleNamespace()
+            plugin.PLUGIN_API_VERSION = "1"
+            plugin.PLUGIN_NAME = "arena"
             plugin.PLUGIN_PRIORITY = 500
-            plugin.can_resolve = lambda target, _context: target.startswith("root://")
-            plugin.resolve = lambda _target, _context: []
+            plugin.can_resolve = lambda target, _context: target.startswith(
+                ("root://", "https://www.are.na/block/")
+            )
+
+            def resolve(target: str, _context: dict[str, object]) -> list[dict]:
+                if target != "root://channel":
+                    return []
+                return [
+                    {
+                        "source": target,
+                        "label": "entry.md",
+                        "content": "entry content",
+                        "metadata": {
+                            "provider": "arena",
+                            "block_id": 42,
+                            "block_type": "Link",
+                            "channel_path": "channels/root",
+                            "context_subpath": "channels/root/42.md",
+                        },
+                    }
+                ]
+
+            plugin.resolve = resolve
             plugin.list_targets = lambda _target, _context: {
                 "targets": [
                     {
@@ -509,22 +780,19 @@ def test_embedded_target_allows_file_like_http_link(
             }
             return plugin
 
-    class _URLReference:
-        def __init__(self, url: str, **_kwargs) -> None:
-            assert url == "https://files.example/paper.pdf?download=1"
-            self.output = "pdf content"
+    def _url_reference(*_args, **_kwargs):
+        raise AssertionError("embedded resolution should not fetch unclaimed links")
 
     monkeypatch.setattr(
-        plugin_loader, "_iter_plugin_entrypoints", lambda: [_EmbeddedEntrypoint()]
+        plugin_loader, "_iter_plugin_entrypoints", lambda: [_ArenaEntrypoint()]
     )
-    monkeypatch.setattr(reference_factory, "URLReference", _URLReference)
+    monkeypatch.setattr(reference_factory, "URLReference", _url_reference)
     clear_loaded_plugins_cache()
 
     result = create_file_references(
-        ["root://thread"],
+        ["root://channel"],
         format="raw",
-        target_depth=1,
-        include_parent=False,
+        embedded_resolution=True,
     )
 
-    assert result["concatenated"] == "pdf content"
+    assert result["concatenated"] == "entry content"

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import re
+
+from contextualize.progress import (
+    set_live_progress,
+    progress_summary_lines,
+    record_progress,
+    reset_progress,
+    reset_progress_context,
+    log_progress,
+    set_progress_context,
+    write_progress_log,
+)
+from contextualize.runtime import (
+    get_payload_media_jobs,
+    get_payload_spec_jobs,
+    reset_payload_media_jobs,
+    reset_payload_spec_jobs,
+    reset_verbose_logging,
+    set_payload_media_jobs,
+    set_payload_spec_jobs,
+    set_verbose_logging,
+)
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+
+def _strip_ansi(value: str) -> str:
+    return _ANSI_RE.sub("", value)
+
+
+def test_progress_summary_groups_by_context_provider_operation() -> None:
+    reset_progress()
+    token = set_progress_context("gamedev")
+    try:
+        record_progress("arena", "channel", "cache_hit")
+        record_progress("arena", "channel", "cache_hit")
+        record_progress("arena", "media", "processed")
+    finally:
+        reset_progress_context(token)
+
+    lines = progress_summary_lines()
+
+    assert "Progress summary:" in lines
+    assert "  context gamedev:" in lines
+    assert "    arena channel: cache_hit=2" in lines
+    assert "    arena media: processed=1" in lines
+    reset_progress()
+
+
+def test_payload_job_overrides_take_precedence_over_env(monkeypatch) -> None:
+    monkeypatch.setenv("CONTEXTUALIZE_PAYLOAD_SPEC_JOBS", "3")
+    monkeypatch.setenv("CONTEXTUALIZE_PAYLOAD_MEDIA_JOBS", "2")
+    spec_token = set_payload_spec_jobs(9)
+    media_token = set_payload_media_jobs(6)
+    try:
+        assert get_payload_spec_jobs() == 9
+        assert get_payload_media_jobs() == 6
+    finally:
+        reset_payload_spec_jobs(spec_token)
+        reset_payload_media_jobs(media_token)
+
+    assert get_payload_spec_jobs() == 3
+    assert get_payload_media_jobs() == 2
+
+
+def test_live_progress_uses_rich_task_rows(capsys) -> None:
+    reset_progress()
+    token = set_verbose_logging(True)
+    try:
+        set_live_progress(True, force_terminal=True, transient=False)
+        log_progress("hydrate", "component", "total", count=2)
+        log_progress("hydrate", "component", "start", target="arena")
+        log_progress("arena", "channel", "cache_hit", target="Cached Channel")
+        log_progress(
+            "plugins",
+            "embedded-list",
+            "start",
+            detail="targets=3 jobs=2",
+        )
+        log_progress("plugins", "embedded-list", "done", detail="targets")
+        write_progress_log("[audio-transcription] request start")
+        log_progress("hydrate", "component", "done", target="arena")
+    finally:
+        set_live_progress(False)
+        reset_verbose_logging(token)
+
+    captured = _strip_ansi(capsys.readouterr().err)
+    assert "[progress]" not in captured
+    assert "progress:" not in captured
+    assert "components" in captured
+    assert "arena channel" in captured
+    assert "plugins embedded list" in captured
+    assert "3/3" in captured
+    assert "[audio-transcription] request start" in captured
+    assert "hit=1" in captured
+    assert "  hydrate component: total=2 done=1" in progress_summary_lines()
+    assert "  arena channel: cache_hit=1" in progress_summary_lines()
+    reset_progress()
+
+
+def test_live_progress_resets_embedded_target_counts(capsys) -> None:
+    reset_progress()
+    token = set_verbose_logging(True)
+    try:
+        set_live_progress(True, force_terminal=True, transient=False)
+        log_progress(
+            "plugins",
+            "embedded-resolve",
+            "start",
+            detail="targets=1 jobs=2",
+        )
+        log_progress("plugins", "embedded-resolve", "processed", target="demo://a")
+        log_progress("plugins", "embedded-resolve", "done", detail="targets")
+        log_progress(
+            "plugins",
+            "embedded-resolve",
+            "start",
+            detail="targets=3 jobs=2",
+        )
+        log_progress("plugins", "embedded-resolve", "processed", target="demo://b")
+    finally:
+        set_live_progress(False)
+        reset_verbose_logging(token)
+
+    captured = _strip_ansi(capsys.readouterr().err)
+    assert "1/3" in captured
+    assert "0/3 done=1" not in captured
+    reset_progress()

--- a/uv.lock
+++ b/uv.lock
@@ -541,6 +541,7 @@ dependencies = [
     { name = "pyperclip" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "rich" },
     { name = "tiktoken" },
 ]
 
@@ -559,6 +560,7 @@ requires-dist = [
     { name = "pyperclip", specifier = ">=1.8.2" },
     { name = "pyyaml" },
     { name = "requests", specifier = ">=2.25.0" },
+    { name = "rich", specifier = ">=14.1.0" },
     { name = "tiktoken", specifier = ">=0.6.0" },
 ]
 provides-extras = ["plugins"]


### PR DESCRIPTION
Replaces target-traversal hydration with embedded resolution and parallelizes media work behind live progress.

- `--target-depth` / `--target-scope` / `--include-parent` → `--embedded-resolution` / `--no-embedded-resolution`; embedded targets now resolve in parallel, preserving parent paths and sidecars.
- Media rendering runs under bounded concurrency with pooled codex app-server sessions; new `--spec-jobs` / `--media-jobs` tune the limits.
- Live progress view + end-of-run summary under `--verbose`.
- Audio transcription caching falls back to a stale result on transient errors instead of failing.
- nix: new `manual` activation mode that skips home-activation hydration.
