### PR TITLE
feat: public resolve_refs API and plugin extension hooks

### DIFF
--- a/src/contextualize/__init__.py
+++ b/src/contextualize/__init__.py
@@ -1,3 +1,5 @@
 """contextualize package."""
 
-__all__: list[str] = []
+from .api import ResolvedRef, resolve_refs
+
+__all__: list[str] = ["resolve_refs", "ResolvedRef"]

--- a/src/contextualize/api.py
+++ b/src/contextualize/api.py
@@ -1,0 +1,69 @@
+"""Public entry points for embedding contextualize in other tools.
+
+`resolve_refs` is a thin, stable wrapper over the same resolution the `cat`
+command uses: it turns targets (files, URLs, plugin refs) into documents that
+carry their authored `prose`. Consumers (e.g. an analyzer plugin) call this
+rather than reaching into internal resolution functions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ResolvedRef:
+    source: str
+    label: str
+    content: str
+    prose: str | None
+    prose_authors: list[str]
+    metadata: dict[str, Any]
+
+
+def _to_resolved_ref(ref: Any) -> ResolvedRef:
+    document = getattr(ref, "document", None)
+    if document is not None:
+        source = getattr(ref, "source", "") or ""
+        return ResolvedRef(
+            source=source,
+            label=getattr(document, "label", "") or source,
+            content=getattr(document, "content", "") or "",
+            prose=getattr(document, "prose", None),
+            prose_authors=list(getattr(document, "prose_authors", []) or []),
+            metadata=dict(getattr(document, "metadata", {}) or {}),
+        )
+    content = (
+        getattr(ref, "original_file_content", None)
+        or getattr(ref, "file_content", None)
+        or ""
+    )
+    source = getattr(ref, "path", None) or getattr(ref, "source", "") or ""
+    label = getattr(ref, "label", None)
+    label = label if isinstance(label, str) and label else source
+    return ResolvedRef(
+        source=source,
+        label=label,
+        content=content,
+        prose=None,
+        prose_authors=[],
+        metadata={},
+    )
+
+
+def resolve_refs(targets, **kwargs) -> list[ResolvedRef]:
+    """Resolve targets to documents carrying prose.
+
+    Each item exposes `.source`, `.label`, `.content`, `.prose` (str | None),
+    `.prose_authors`, and `.metadata`. Plain files carry `prose=None`; the caller
+    decides how to treat undeclared prose. Extra keyword arguments are forwarded
+    to the underlying resolver.
+    """
+    from .references.factory import create_file_references
+
+    if isinstance(targets, str):
+        targets = [targets]
+    result = create_file_references(list(targets), **kwargs)
+    refs = result["refs"] if isinstance(result, dict) else result
+    return [_to_resolved_ref(ref) for ref in refs]

--- a/src/contextualize/cli.py
+++ b/src/contextualize/cli.py
@@ -117,6 +117,22 @@ def _extract_stdin_urls(text: str) -> tuple[str, ...]:
     return tuple(urls)
 
 
+def _stdin_is_capturable() -> bool:
+    """True only when stdin carries real piped/redirected data — a pipe (FIFO)
+    or a regular file. A tty has no piped data; a socket or other stream may
+    never send EOF, so reading it would block indefinitely (e.g. under
+    ``direnv exec`` or some non-interactive launchers)."""
+    if sys.stdin.isatty():
+        return False
+    try:
+        import stat
+
+        mode = os.fstat(sys.stdin.fileno()).st_mode
+    except (OSError, ValueError):
+        return False
+    return stat.S_ISFIFO(mode) or stat.S_ISREG(mode)
+
+
 @dataclass
 class _TraceRef:
     path: str
@@ -810,7 +826,7 @@ def cli(
 
     stdin_data = ""
     stdin_binary_path: str | None = None
-    if not sys.stdin.isatty():
+    if _stdin_is_capturable():
         raw = sys.stdin.buffer.read()
         if raw:
             from .references.helpers import detect_media_suffix

--- a/src/contextualize/cli.py
+++ b/src/contextualize/cli.py
@@ -250,10 +250,11 @@ class OrderedGroup(click.Group):
 
     def _sync_dynamic_commands(self) -> None:
         from .plugins.auth import sync_plugin_auth_group
-        from .plugins.cli import sync_plugin_cli_commands
+        from .plugins.cli import sync_plugin_cli_commands, sync_plugin_root_commands
 
         sync_plugin_auth_group(self)
         sync_plugin_cli_commands(self)
+        sync_plugin_root_commands(self)
 
     def format_commands(
         self, ctx: click.Context, formatter: click.HelpFormatter

--- a/src/contextualize/plugins/__init__.py
+++ b/src/contextualize/plugins/__init__.py
@@ -3,6 +3,7 @@ from .cli import (
     loaded_transcription_gates,
     loaded_transcription_providers,
     sync_plugin_cli_commands,
+    sync_plugin_root_commands,
 )
 from .loader import clear_loaded_plugins_cache, get_loaded_plugins
 from .resolve import (
@@ -27,4 +28,5 @@ __all__ = [
     "collect_plugin_cli_overrides",
     "loaded_transcription_providers",
     "loaded_transcription_gates",
+    "sync_plugin_root_commands",
 ]

--- a/src/contextualize/plugins/api.py
+++ b/src/contextualize/plugins/api.py
@@ -87,6 +87,7 @@ ResolveFn = Callable[[str, PluginContext], list[PluginDocument]]
 ListTargetsFn = Callable[[str, PluginContext], PluginListEnvelope]
 MaterializeFn = Callable[[str, PluginContext], list[PluginMaterializedFile]]
 RegisterAuthCommandFn = Callable[[Any], None]
+RegisterCommandFn = Callable[[Any], None]
 ClassifyTargetFn = Callable[[str, PluginContext], PluginTargetDescriptor | None]
 NormalizeManifestConfigFn = Callable[[dict[str, Any] | None], dict[str, Any] | None]
 RegisterCliOptionsFn = Callable[[str, Any], None]
@@ -184,6 +185,7 @@ class LoadedPlugin:
     normalize_manifest_config: NormalizeManifestConfigFn | None = None
     register_cli_options: RegisterCliOptionsFn | None = None
     collect_cli_overrides: CollectCliOverridesFn | None = None
+    register_command: RegisterCommandFn | None = None
     transcription_providers: tuple[TranscriptionProvider, ...] = field(
         default_factory=tuple
     )

--- a/src/contextualize/plugins/api.py
+++ b/src/contextualize/plugins/api.py
@@ -9,10 +9,20 @@ PLUGIN_ENTRYPOINT_GROUP = "contextualize.plugins"
 
 
 class PluginDocument(TypedDict, total=False):
+    """A resolved document.
+
+    `prose` is the authored text without scaffolding (frontmatter, media
+    descriptions, comments, structural markup). Omit it to defer to generic
+    extraction; set to "" to declare the unit carries no authored prose.
+    `prose_authors` lists the distinct authors of `prose`.
+    """
+
     source: str
     label: str
     content: str
     metadata: dict[str, Any]
+    prose: str
+    prose_authors: list[str]
 
 
 class PluginListItem(TypedDict, total=False):

--- a/src/contextualize/plugins/cli.py
+++ b/src/contextualize/plugins/cli.py
@@ -92,3 +92,24 @@ def loaded_transcription_gates() -> tuple[Any, ...]:
     for plugin in get_loaded_plugins():
         gates.extend(plugin.transcription_gates)
     return tuple(gates)
+
+
+_ROOT_COMMANDS_ATTR = "_contextualize_root_command_plugins"
+
+
+def sync_plugin_root_commands(root: click.Group) -> None:
+    registered = set(getattr(root, _ROOT_COMMANDS_ATTR, set()))
+    for plugin in get_loaded_plugins():
+        hook = plugin.register_command
+        if hook is None:
+            continue
+        marker = f"{plugin.name}:{plugin.origin}"
+        if marker in registered:
+            continue
+        try:
+            hook(root)
+        except Exception as exc:
+            _warn(f"plugin '{plugin.name}' register_command failed: {exc}")
+            continue
+        registered.add(marker)
+    setattr(root, _ROOT_COMMANDS_ATTR, registered)

--- a/src/contextualize/plugins/loader.py
+++ b/src/contextualize/plugins/loader.py
@@ -31,6 +31,14 @@ def _as_name(value: Any) -> str | None:
     return text or None
 
 
+def _noop_can_resolve(_target: Any, _context: Any) -> bool:
+    return False
+
+
+def _noop_resolve(_target: Any, _context: Any) -> list:
+    return []
+
+
 def _validate_plugin_callables(
     *,
     name: str,
@@ -44,11 +52,15 @@ def _validate_plugin_callables(
     normalize_manifest_config: Any,
     register_cli_options: Any,
     collect_cli_overrides: Any,
+    register_command: Any,
     transcription_providers: Any,
     transcription_gates: Any,
     plugin_kind: Any,
     priority: int,
 ) -> LoadedPlugin | None:
+    if can_resolve is None and resolve is None:
+        can_resolve = _noop_can_resolve
+        resolve = _noop_resolve
     if not callable(can_resolve):
         _warn(f"plugin '{name}' has non-callable can_resolve ({origin})")
         return None
@@ -99,6 +111,12 @@ def _validate_plugin_callables(
             _warn(f"plugin '{name}' has non-callable collect_cli_overrides ({origin})")
             return None
         cli_collect_hook = collect_cli_overrides
+    register_command_hook = None
+    if register_command is not None:
+        if not callable(register_command):
+            _warn(f"plugin '{name}' has non-callable register_command ({origin})")
+            return None
+        register_command_hook = register_command
     provider_items: tuple[TranscriptionProvider, ...] = ()
     if transcription_providers is not None:
         if not isinstance(transcription_providers, (list, tuple)):
@@ -154,6 +172,7 @@ def _validate_plugin_callables(
         normalize_manifest_config=normalize_hook,
         register_cli_options=cli_register_hook,
         collect_cli_overrides=cli_collect_hook,
+        register_command=register_command_hook,
         transcription_providers=provider_items,
         transcription_gates=gate_items,
         plugin_kind=normalized_kind,
@@ -245,6 +264,7 @@ def _load_entrypoint_plugins() -> list[_PluginCandidate]:
             ),
             register_cli_options=getattr(plugin_obj, "register_cli_options", None),
             collect_cli_overrides=getattr(plugin_obj, "collect_cli_overrides", None),
+            register_command=getattr(plugin_obj, "register_command", None),
             transcription_providers=transcription_providers,
             transcription_gates=transcription_gates,
             plugin_kind=getattr(plugin_obj, "PLUGIN_KIND", None),

--- a/src/contextualize/plugins/reference.py
+++ b/src/contextualize/plugins/reference.py
@@ -15,6 +15,8 @@ class PluginResolvedDocument:
     label: str
     content: str
     metadata: dict[str, Any] = field(default_factory=dict)
+    prose: str | None = None
+    prose_authors: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -49,6 +51,14 @@ class PluginReference:
         if isinstance(value, str) and value.strip():
             return value
         return self.document.label
+
+    @property
+    def prose(self) -> str | None:
+        return self.document.prose
+
+    @property
+    def prose_authors(self) -> list[str]:
+        return self.document.prose_authors
 
     def read(self) -> str:
         return self.original_file_content

--- a/src/contextualize/plugins/resolve.py
+++ b/src/contextualize/plugins/resolve.py
@@ -78,11 +78,21 @@ def _normalize_plugin_document(
         metadata = {}
     metadata.setdefault("plugin_name", plugin_name)
     metadata.setdefault("provider", plugin_name)
+    prose_raw = item.get("prose")
+    prose = prose_raw if isinstance(prose_raw, str) else None
+    authors_raw = item.get("prose_authors")
+    prose_authors = (
+        [a for a in authors_raw if isinstance(a, str)]
+        if isinstance(authors_raw, list)
+        else []
+    )
     return PluginResolvedDocument(
         source=source_raw,
         label=label_raw,
         content=content_raw,
         metadata=metadata,
+        prose=prose,
+        prose_authors=prose_authors,
     )
 
 


### PR DESCRIPTION
Adds the public ref-resolution and plugin-extension surface consumed by cx-pangram.

- `resolve_refs` / `ResolvedRef`: public API for resolving refs to documents.
- `prose` / `prose_authors`: document contract for authored text with scaffolding stripped.
- `register_command`: plugin hook for contributing root-level commands.
- Restricts stdin capture to pipes/regular files so never-EOF streams don't hang.
